### PR TITLE
Update link in build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/AY2425S1-CS2103-F13-2/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2425S1-CS2103-F13-2/tp/actions/workflows/gradle.yml)
+[![Java CI](https://github.com/AY2425S1-CS2103-F13-2/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2425S1-CS2103-F13-2/tp/actions/workflows/gradle.yml)
 [![codecov](https://codecov.io/gh/AY2425S1-CS2103-F13-2/tp/graph/badge.svg?token=7KT6LGDAO8)](https://codecov.io/gh/AY2425S1-CS2103-F13-2/tp)
 
 ![Ui](docs/images/Ui.png)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![CI Status](https://github.com/AY2425S1-CS2103-F13-2/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2425S1-CS2103-F13-2/tp/actions/workflows/gradle.yml)
 [![codecov](https://codecov.io/gh/AY2425S1-CS2103-F13-2/tp/graph/badge.svg?token=7KT6LGDAO8)](https://codecov.io/gh/AY2425S1-CS2103-F13-2/tp)
 
 ![Ui](docs/images/Ui.png)


### PR DESCRIPTION
Resolves #30.

<img width="817" alt="Screenshot 2024-10-05 at 11 20 18 PM" src="https://github.com/user-attachments/assets/6f6004d8-22a8-4bb9-a726-9c2779995846">

Build status badge in README.md is now linked to the `gradle.yml` github action to reflect the build status of our project.