### PR TITLE
Add use case for assign command to developer guide

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -313,7 +313,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 (For all use cases below, the **System** is the `EventTory` and the **Actor** is the `user`, unless specified otherwise)
 
-**Use case: Create an event**
+**Use case: UC01 - Create an event**
 
 **MSS**
 
@@ -337,11 +337,9 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case ends.
 
-**System: EventTory** 
+---
 
 **Use case: UC02 - Assign a vendor to an event** 
-
-**Actors: User**
 
 **MSS** 
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -344,16 +344,14 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS** 
 
 1. User enters command to assign a vendor to an event.
-2. System verifies that both the vendor and event exist.
-3. System verifies that the vendor is not already assigned to the event.
-4. System assigns the vendor to the event.
-5. System displays a success message.
+2. System assigns the vendor to the event.
+3. System displays a success message.
 
     Use case ends.
 
 **Extensions**
 
-* 1a. The command entered by the user does not exist.
+* 1a. The command format entered by the user is invalid.
 
   * 1a1. System shows an error message and displays the correct command format.
 
@@ -371,9 +369,9 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case ends.
 
-* 3a. The vendor has already been assigned to the event.
+* 2c. The vendor has already been assigned to the event.
 
-  * 3a1. System shows an error message.
+  * 2c1. System shows an error message.
 
       Use case ends.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -337,6 +337,48 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case ends.
 
+**System: EventTory** 
+
+**Use case: UC02 - Assign a vendor to an event** 
+
+**Actors: User**
+
+**MSS** 
+
+1. User enters command to assign a vendor to an event.
+2. System verifies that both the vendor and event exist.
+3. System verifies that the vendor is not already assigned to the event.
+4. System assigns the vendor to the event.
+5. System displays a success message.
+
+    Use case ends.
+
+**Extensions**
+
+* 1a. The command entered by the user does not exist.
+
+  * 1a1. System shows an error message and displays the correct command format.
+
+      Use case ends.
+
+* 2a. The event does not exist.
+
+  * 2a1. System shows an error message.
+
+      Use case ends.
+
+* 2b. The vendor does not exist.
+
+  * 2b1. System shows an error message.
+
+      Use case ends.
+
+* 3a. The vendor has already been assigned to the event.
+
+  * 3a1. System shows an error message.
+
+      Use case ends.
+
 *{More to be added}*
 
 ### Non-Functional Requirements


### PR DESCRIPTION
Resolves #36.

Add use for the `assign` command to the developer guide.