### PR TITLE
Vendor parser support

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -38,8 +38,7 @@ public class Messages {
         builder.append(vendor.getName())
                 .append("; Phone: ")
                 .append(vendor.getPhone())
-                .append("; Email: ")
-                .append("; Address: ")
+                .append("; Description: ")
                 .append(vendor.getDescription())
                 .append("; Tags: ");
         vendor.getTags().forEach(builder::append);

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -17,20 +17,20 @@ import seedu.address.model.vendor.Vendor;
  */
 public class AddCommand extends Command {
 
-    public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_WORD = "create_vendor";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a vendor to the address book. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
-            + PREFIX_DESCRIPTION + "ADDRESS "
+            + PREFIX_DESCRIPTION + "DESCRIPTION "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "John Doe "
+            + PREFIX_NAME + "Adam's Bakery "
             + PREFIX_PHONE + "98765432 "
-            + PREFIX_DESCRIPTION + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_DESCRIPTION + "Pastries and cakes, bake in a day "
+            + PREFIX_TAG + "pastry "
+            + PREFIX_TAG + "fast";
 
     public static final String MESSAGE_SUCCESS = "New vendor added: %1$s";
     public static final String MESSAGE_DUPLICATE_VENDOR = "This vendor already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/CreateVendorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateVendorCommand.java
@@ -15,21 +15,14 @@ import seedu.address.model.vendor.Vendor;
 /**
  * Adds a vendor to the address book.
  */
-public class AddCommand extends Command {
+public class CreateVendorCommand extends Command {
 
     public static final String COMMAND_WORD = "create_vendor";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a vendor to the address book. "
-            + "Parameters: "
-            + PREFIX_NAME + "NAME "
-            + PREFIX_PHONE + "PHONE "
-            + PREFIX_DESCRIPTION + "DESCRIPTION "
-            + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "Adam's Bakery "
-            + PREFIX_PHONE + "98765432 "
-            + PREFIX_DESCRIPTION + "Pastries and cakes, bake in a day "
-            + PREFIX_TAG + "pastry "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a vendor to the address book. " + "Parameters: "
+            + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_DESCRIPTION + "DESCRIPTION " + "[" + PREFIX_TAG
+            + "TAG]...\n" + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Adam's Bakery " + PREFIX_PHONE
+            + "98765432 " + PREFIX_DESCRIPTION + "Pastries and cakes, bake in a day " + PREFIX_TAG + "pastry "
             + PREFIX_TAG + "fast";
 
     public static final String MESSAGE_SUCCESS = "New vendor added: %1$s";
@@ -40,7 +33,7 @@ public class AddCommand extends Command {
     /**
      * Creates an AddCommand to add the specified {@code Vendor}
      */
-    public AddCommand(Vendor vendor) {
+    public CreateVendorCommand(Vendor vendor) {
         requireNonNull(vendor);
         toAdd = vendor;
     }
@@ -64,18 +57,16 @@ public class AddCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof AddCommand)) {
+        if (!(other instanceof CreateVendorCommand)) {
             return false;
         }
 
-        AddCommand otherAddCommand = (AddCommand) other;
+        CreateVendorCommand otherAddCommand = (CreateVendorCommand) other;
         return toAdd.equals(otherAddCommand.toAdd);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
-                .add("toAdd", toAdd)
-                .toString();
+        return new ToStringBuilder(this).add("toAdd", toAdd).toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,9 +8,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -32,7 +32,6 @@ public class AddressBookParser {
 
     /**
      * Parses user input into command for execution.
-     *
      * @param userInput full user input string
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
@@ -46,15 +45,16 @@ public class AddressBookParser {
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
 
-        // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)
+        // Note to developers: Change the log level in config.json to enable lower level
+        // (i.e., FINE, FINER and lower)
         // log messages such as the one below.
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
         switch (commandWord) {
 
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+        case CreateVendorCommand.COMMAND_WORD:
+            return new CreateVendorCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -9,7 +9,7 @@ public class CliSyntax {
     /* Prefix definitions */
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_DESCRIPTION = new Prefix("a/");
+    public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CreateVendorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateVendorCommandParser.java
@@ -9,7 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.vendor.Description;
@@ -20,21 +20,20 @@ import seedu.address.model.vendor.Vendor;
 /**
  * Parses input arguments and creates a new AddCommand object
  */
-public class AddCommandParser implements Parser<AddCommand> {
+public class CreateVendorCommandParser implements Parser<CreateVendorCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
-     *
      * @throws ParseException if the user input does not conform the expected format
      */
-    public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
-                PREFIX_DESCRIPTION, PREFIX_TAG);
+    public CreateVendorCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_DESCRIPTION,
+                PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_PHONE)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateVendorCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_DESCRIPTION);
@@ -45,13 +44,12 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         Vendor vendor = new Vendor(name, phone, description, tagList);
 
-        return new AddCommand(vendor);
+        return new CreateVendorCommand(vendor);
     }
 
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values
-     * in the given
-     * {@code ArgumentMultimap}.
+     * in the given {@code ArgumentMultimap}.
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -71,14 +71,14 @@ public class LogicManagerTest {
 
     @Test
     public void execute_storageThrowsIoException_throwsCommandException() {
-        assertCommandFailureForExceptionFromStorage(DUMMY_IO_EXCEPTION, String.format(
-                LogicManager.FILE_OPS_ERROR_FORMAT, DUMMY_IO_EXCEPTION.getMessage()));
+        assertCommandFailureForExceptionFromStorage(DUMMY_IO_EXCEPTION,
+                String.format(LogicManager.FILE_OPS_ERROR_FORMAT, DUMMY_IO_EXCEPTION.getMessage()));
     }
 
     @Test
     public void execute_storageThrowsAdException_throwsCommandException() {
-        assertCommandFailureForExceptionFromStorage(DUMMY_AD_EXCEPTION, String.format(
-                LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT, DUMMY_AD_EXCEPTION.getMessage()));
+        assertCommandFailureForExceptionFromStorage(DUMMY_AD_EXCEPTION,
+                String.format(LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT, DUMMY_AD_EXCEPTION.getMessage()));
     }
 
     @Test
@@ -87,16 +87,14 @@ public class LogicManagerTest {
     }
 
     /**
-     * Executes the command and confirms that
-     * - no exceptions are thrown <br>
+     * Executes the command and confirms that - no exceptions are thrown <br>
      * - the feedback message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in
      * {@code expectedModel} <br>
-     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
-    private void assertCommandSuccess(String inputCommand, String expectedMessage,
-            Model expectedModel) throws CommandException, ParseException {
+    private void assertCommandSuccess(String inputCommand, String expectedMessage, Model expectedModel)
+            throws CommandException, ParseException {
         CommandResult result = logic.execute(inputCommand);
         assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedModel, model);
@@ -105,7 +103,6 @@ public class LogicManagerTest {
     /**
      * Executes the command, confirms that a ParseException is thrown and that the
      * result message is correct.
-     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertParseException(String inputCommand, String expectedMessage) {
@@ -115,7 +112,6 @@ public class LogicManagerTest {
     /**
      * Executes the command, confirms that a CommandException is thrown and that the
      * result message is correct.
-     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandException(String inputCommand, String expectedMessage) {
@@ -125,7 +121,6 @@ public class LogicManagerTest {
     /**
      * Executes the command, confirms that the exception is thrown and that the
      * result message is correct.
-     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
@@ -135,12 +130,11 @@ public class LogicManagerTest {
     }
 
     /**
-     * Executes the command and confirms that
-     * - the {@code expectedException} is thrown <br>
+     * Executes the command and confirms that - the {@code expectedException} is
+     * thrown <br>
      * - the resulting error message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in
      * {@code expectedModel} <br>
-     *
      * @see #assertCommandSuccess(String, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
@@ -152,7 +146,6 @@ public class LogicManagerTest {
     /**
      * Tests the Logic component's handling of an {@code IOException} thrown by the
      * Storage component.
-     *
      * @param e               the exception to be thrown by the Storage component
      * @param expectedMessage the message expected inside exception thrown by the
      *                        Logic component
@@ -164,8 +157,7 @@ public class LogicManagerTest {
         // when saving
         JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(prefPath) {
             @Override
-            public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath)
-                    throws IOException {
+            public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
                 throw e;
             }
         };
@@ -177,8 +169,7 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing an add command
-        String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + DESCRIPTION_DESC_AMY;
+        String addCommand = CreateVendorCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY;
         Vendor expectedVendor = new VendorBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addVendor(expectedVendor);

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -15,7 +15,8 @@ import seedu.address.model.vendor.Vendor;
 import seedu.address.testutil.VendorBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code AddCommand}.
+ * Contains integration tests (interaction with the Model) for
+ * {@code AddCommand}.
  */
 public class AddCommandIntegrationTest {
 
@@ -33,16 +34,15 @@ public class AddCommandIntegrationTest {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addVendor(validVendor);
 
-        assertCommandSuccess(new AddCommand(validVendor), model,
-                String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validVendor)),
-                expectedModel);
+        assertCommandSuccess(new CreateVendorCommand(validVendor), model,
+                String.format(CreateVendorCommand.MESSAGE_SUCCESS, Messages.format(validVendor)), expectedModel);
     }
 
     @Test
     public void execute_duplicateVendor_throwsCommandException() {
         Vendor vendorInList = model.getAddressBook().getVendorList().get(0);
-        assertCommandFailure(new AddCommand(vendorInList), model,
-                AddCommand.MESSAGE_DUPLICATE_VENDOR);
+        assertCommandFailure(new CreateVendorCommand(vendorInList), model,
+                CreateVendorCommand.MESSAGE_DUPLICATE_VENDOR);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -29,7 +29,7 @@ public class AddCommandTest {
 
     @Test
     public void constructor_nullVendor_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AddCommand(null));
+        assertThrows(NullPointerException.class, () -> new CreateVendorCommand(null));
     }
 
     @Test
@@ -37,9 +37,9 @@ public class AddCommandTest {
         ModelStubAcceptingVendorAdded modelStub = new ModelStubAcceptingVendorAdded();
         Vendor validVendor = new VendorBuilder().build();
 
-        CommandResult commandResult = new AddCommand(validVendor).execute(modelStub);
+        CommandResult commandResult = new CreateVendorCommand(validVendor).execute(modelStub);
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validVendor)),
+        assertEquals(String.format(CreateVendorCommand.MESSAGE_SUCCESS, Messages.format(validVendor)),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validVendor), modelStub.vendorsAdded);
     }
@@ -47,24 +47,25 @@ public class AddCommandTest {
     @Test
     public void execute_duplicateVendor_throwsCommandException() {
         Vendor validVendor = new VendorBuilder().build();
-        AddCommand addCommand = new AddCommand(validVendor);
+        CreateVendorCommand addCommand = new CreateVendorCommand(validVendor);
         ModelStub modelStub = new ModelStubWithVendor(validVendor);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_VENDOR, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class, CreateVendorCommand.MESSAGE_DUPLICATE_VENDOR,
+                () -> addCommand.execute(modelStub));
     }
 
     @Test
     public void equals() {
         Vendor alice = new VendorBuilder().withName("Alice").build();
         Vendor bob = new VendorBuilder().withName("Bob").build();
-        AddCommand addAliceCommand = new AddCommand(alice);
-        AddCommand addBobCommand = new AddCommand(bob);
+        CreateVendorCommand addAliceCommand = new CreateVendorCommand(alice);
+        CreateVendorCommand addBobCommand = new CreateVendorCommand(bob);
 
         // same object -> returns true
         assertTrue(addAliceCommand.equals(addAliceCommand));
 
         // same values -> returns true
-        AddCommand addAliceCommandCopy = new AddCommand(alice);
+        CreateVendorCommand addAliceCommandCopy = new CreateVendorCommand(alice);
         assertTrue(addAliceCommand.equals(addAliceCommandCopy));
 
         // different types -> returns false
@@ -79,8 +80,8 @@ public class AddCommandTest {
 
     @Test
     public void toStringMethod() {
-        AddCommand addCommand = new AddCommand(ALICE);
-        String expected = AddCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
+        CreateVendorCommand addCommand = new CreateVendorCommand(ALICE);
+        String expected = CreateVendorCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
         assertEquals(expected, addCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -50,8 +50,8 @@ public class AddCommandTest {
         CreateVendorCommand addCommand = new CreateVendorCommand(validVendor);
         ModelStub modelStub = new ModelStubWithVendor(validVendor);
 
-        assertThrows(CommandException.class, CreateVendorCommand.MESSAGE_DUPLICATE_VENDOR,
-                () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class, CreateVendorCommand.MESSAGE_DUPLICATE_VENDOR, ()
+            -> addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -40,128 +40,131 @@ import seedu.address.model.vendor.Vendor;
 import seedu.address.testutil.VendorBuilder;
 
 public class AddCommandParserTest {
-        private CreateVendorCommandParser parser = new CreateVendorCommandParser();
+    private CreateVendorCommandParser parser = new CreateVendorCommandParser();
 
-        @Test
-        public void parse_allFieldsPresent_success() {
-                Vendor expectedVendor = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Vendor expectedVendor = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
 
-                // whitespace only preamble
-                assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB
-                                + TAG_DESC_FRIEND, new CreateVendorCommand(expectedVendor));
+        // whitespace only preamble
+        assertParseSuccess(parser,
+                PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_FRIEND,
+                new CreateVendorCommand(expectedVendor));
 
-                // multiple tags - all accepted
-                Vendor expectedVendorMultipleTags = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                                .build();
-                assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND
-                                + TAG_DESC_FRIEND, new CreateVendorCommand(expectedVendorMultipleTags));
-        }
+        // multiple tags - all accepted
+        Vendor expectedVendorMultipleTags = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+                .build();
+        assertParseSuccess(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                new CreateVendorCommand(expectedVendorMultipleTags));
+    }
 
-        @Test
-        public void parse_repeatedNonTagValue_failure() {
-                String validExpectedVendorString = NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB
-                                + TAG_DESC_FRIEND;
+    @Test
+    public void parse_repeatedNonTagValue_failure() {
+        String validExpectedVendorString = NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_FRIEND;
 
-                // multiple names
-                assertParseFailure(parser, NAME_DESC_AMY + validExpectedVendorString,
-                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+        // multiple names
+        assertParseFailure(parser, NAME_DESC_AMY + validExpectedVendorString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
-                // multiple phones
-                assertParseFailure(parser, PHONE_DESC_AMY + validExpectedVendorString,
-                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+        // multiple phones
+        assertParseFailure(parser, PHONE_DESC_AMY + validExpectedVendorString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-                // multiple descriptiones
-                assertParseFailure(parser, DESCRIPTION_DESC_AMY + validExpectedVendorString,
-                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
+        // multiple descriptiones
+        assertParseFailure(parser, DESCRIPTION_DESC_AMY + validExpectedVendorString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
 
-                // multiple fields repeated
-                assertParseFailure(parser,
-                                validExpectedVendorString + PHONE_DESC_AMY + NAME_DESC_AMY + DESCRIPTION_DESC_AMY
-                                                + validExpectedVendorString,
-                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_DESCRIPTION,
-                                                PREFIX_PHONE));
+        // multiple fields repeated
+        assertParseFailure(parser,
+                validExpectedVendorString + PHONE_DESC_AMY + NAME_DESC_AMY + DESCRIPTION_DESC_AMY
+                        + validExpectedVendorString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_PHONE));
 
-                // invalid value followed by valid value
+        // invalid value followed by valid value
 
-                // invalid name
-                assertParseFailure(parser, INVALID_NAME_DESC + validExpectedVendorString,
-                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME_DESC + validExpectedVendorString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
-                // invalid phone
-                assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedVendorString,
-                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+        // invalid phone
+        assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedVendorString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-                // invalid description
-                assertParseFailure(parser, INVALID_DESCRIPTION_DESC + validExpectedVendorString,
-                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
+        // invalid description
+        assertParseFailure(parser, INVALID_DESCRIPTION_DESC + validExpectedVendorString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
 
-                // valid value followed by invalid value
+        // valid value followed by invalid value
 
-                // invalid name
-                assertParseFailure(parser, validExpectedVendorString + INVALID_NAME_DESC,
-                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+        // invalid name
+        assertParseFailure(parser, validExpectedVendorString + INVALID_NAME_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
-                // invalid phone
-                assertParseFailure(parser, validExpectedVendorString + INVALID_PHONE_DESC,
-                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+        // invalid phone
+        assertParseFailure(parser, validExpectedVendorString + INVALID_PHONE_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-                // invalid description
-                assertParseFailure(parser, validExpectedVendorString + INVALID_DESCRIPTION_DESC,
-                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
-        }
+        // invalid description
+        assertParseFailure(parser, validExpectedVendorString + INVALID_DESCRIPTION_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
+    }
 
-        @Test
-        public void parse_optionalFieldsMissing_success() {
-                // zero tags
-                Vendor expectedVendor = new VendorBuilder(AMY).withTags().build();
-                assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY,
-                                new CreateVendorCommand(expectedVendor));
-        }
+    @Test
+    public void parse_optionalFieldsMissing_success() {
+        // zero tags
+        Vendor expectedVendor = new VendorBuilder(AMY).withTags().build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY,
+                new CreateVendorCommand(expectedVendor));
+    }
 
-        @Test
-        public void parse_compulsoryFieldMissing_failure() {
-                String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                                CreateVendorCommand.MESSAGE_USAGE);
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateVendorCommand.MESSAGE_USAGE);
 
-                // missing name prefix
-                assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
+        // missing name prefix
+        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
 
-                // missing phone prefix
-                assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
+        // missing phone prefix
+        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
 
-                // missing description prefix
-                assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_DESCRIPTION_BOB, expectedMessage);
+        // missing description prefix
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_DESCRIPTION_BOB, expectedMessage);
 
-                // all prefixes missing
-                assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_DESCRIPTION_BOB, expectedMessage);
-        }
+        // all prefixes missing
+        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_DESCRIPTION_BOB, expectedMessage);
+    }
 
-        @Test
-        public void parse_invalidValue_failure() {
-                // invalid name
-                assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND
-                                + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser,
+                INVALID_NAME_DESC + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                Name.MESSAGE_CONSTRAINTS);
 
-                // invalid phone
-                assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND
-                                + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+        // invalid phone
+        assertParseFailure(parser,
+                NAME_DESC_BOB + INVALID_PHONE_DESC + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                Phone.MESSAGE_CONSTRAINTS);
 
-                // invalid description
-                assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC + TAG_DESC_HUSBAND
-                                + TAG_DESC_FRIEND, Description.MESSAGE_CONSTRAINTS);
+        // invalid description
+        assertParseFailure(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                Description.MESSAGE_CONSTRAINTS);
 
-                // invalid tag
-                assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + INVALID_TAG_DESC
-                                + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+        // invalid tag
+        assertParseFailure(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND,
+                Tag.MESSAGE_CONSTRAINTS);
 
-                // two invalid values, only first invalid value reported
-                assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC,
-                                Name.MESSAGE_CONSTRAINTS);
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC,
+                Name.MESSAGE_CONSTRAINTS);
 
-                // non-empty preamble
-                assertParseFailure(parser,
-                                PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB
-                                                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateVendorCommand.MESSAGE_USAGE));
-        }
+        // non-empty preamble
+        assertParseFailure(parser,
+                PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND
+                        + TAG_DESC_FRIEND,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateVendorCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -31,7 +31,7 @@ import static seedu.address.testutil.TypicalVendors.BOB;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.vendor.Description;
 import seedu.address.model.vendor.Name;
@@ -40,132 +40,128 @@ import seedu.address.model.vendor.Vendor;
 import seedu.address.testutil.VendorBuilder;
 
 public class AddCommandParserTest {
-    private AddCommandParser parser = new AddCommandParser();
+        private CreateVendorCommandParser parser = new CreateVendorCommandParser();
 
-    @Test
-    public void parse_allFieldsPresent_success() {
-        Vendor expectedVendor = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        @Test
+        public void parse_allFieldsPresent_success() {
+                Vendor expectedVendor = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
 
-        // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB
-                + DESCRIPTION_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedVendor));
+                // whitespace only preamble
+                assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB
+                                + TAG_DESC_FRIEND, new CreateVendorCommand(expectedVendor));
 
-        // multiple tags - all accepted
-        Vendor expectedVendorMultipleTags = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                .build();
-        assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND
-                        + TAG_DESC_FRIEND,
-                new AddCommand(expectedVendorMultipleTags));
-    }
+                // multiple tags - all accepted
+                Vendor expectedVendorMultipleTags = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+                                .build();
+                assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND
+                                + TAG_DESC_FRIEND, new CreateVendorCommand(expectedVendorMultipleTags));
+        }
 
-    @Test
-    public void parse_repeatedNonTagValue_failure() {
-        String validExpectedVendorString = NAME_DESC_BOB + PHONE_DESC_BOB
-                + DESCRIPTION_DESC_BOB + TAG_DESC_FRIEND;
+        @Test
+        public void parse_repeatedNonTagValue_failure() {
+                String validExpectedVendorString = NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB
+                                + TAG_DESC_FRIEND;
 
-        // multiple names
-        assertParseFailure(parser, NAME_DESC_AMY + validExpectedVendorString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+                // multiple names
+                assertParseFailure(parser, NAME_DESC_AMY + validExpectedVendorString,
+                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
-        // multiple phones
-        assertParseFailure(parser, PHONE_DESC_AMY + validExpectedVendorString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+                // multiple phones
+                assertParseFailure(parser, PHONE_DESC_AMY + validExpectedVendorString,
+                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-        // multiple descriptiones
-        assertParseFailure(parser, DESCRIPTION_DESC_AMY + validExpectedVendorString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
+                // multiple descriptiones
+                assertParseFailure(parser, DESCRIPTION_DESC_AMY + validExpectedVendorString,
+                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
 
-        // multiple fields repeated
-        assertParseFailure(parser,
-                validExpectedVendorString + PHONE_DESC_AMY + NAME_DESC_AMY + DESCRIPTION_DESC_AMY
-                        + validExpectedVendorString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_DESCRIPTION,
-                        PREFIX_PHONE));
+                // multiple fields repeated
+                assertParseFailure(parser,
+                                validExpectedVendorString + PHONE_DESC_AMY + NAME_DESC_AMY + DESCRIPTION_DESC_AMY
+                                                + validExpectedVendorString,
+                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_DESCRIPTION,
+                                                PREFIX_PHONE));
 
-        // invalid value followed by valid value
+                // invalid value followed by valid value
 
-        // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + validExpectedVendorString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+                // invalid name
+                assertParseFailure(parser, INVALID_NAME_DESC + validExpectedVendorString,
+                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
-        // invalid phone
-        assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedVendorString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+                // invalid phone
+                assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedVendorString,
+                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-        // invalid description
-        assertParseFailure(parser, INVALID_DESCRIPTION_DESC + validExpectedVendorString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
+                // invalid description
+                assertParseFailure(parser, INVALID_DESCRIPTION_DESC + validExpectedVendorString,
+                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
 
-        // valid value followed by invalid value
+                // valid value followed by invalid value
 
-        // invalid name
-        assertParseFailure(parser, validExpectedVendorString + INVALID_NAME_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+                // invalid name
+                assertParseFailure(parser, validExpectedVendorString + INVALID_NAME_DESC,
+                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
-        // invalid phone
-        assertParseFailure(parser, validExpectedVendorString + INVALID_PHONE_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+                // invalid phone
+                assertParseFailure(parser, validExpectedVendorString + INVALID_PHONE_DESC,
+                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-        // invalid description
-        assertParseFailure(parser, validExpectedVendorString + INVALID_DESCRIPTION_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
-    }
+                // invalid description
+                assertParseFailure(parser, validExpectedVendorString + INVALID_DESCRIPTION_DESC,
+                                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
+        }
 
-    @Test
-    public void parse_optionalFieldsMissing_success() {
-        // zero tags
-        Vendor expectedVendor = new VendorBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY,
-                new AddCommand(expectedVendor));
-    }
+        @Test
+        public void parse_optionalFieldsMissing_success() {
+                // zero tags
+                Vendor expectedVendor = new VendorBuilder(AMY).withTags().build();
+                assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY,
+                                new CreateVendorCommand(expectedVendor));
+        }
 
-    @Test
-    public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        @Test
+        public void parse_compulsoryFieldMissing_failure() {
+                String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                                CreateVendorCommand.MESSAGE_USAGE);
 
-        // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB,
-                expectedMessage);
+                // missing name prefix
+                assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
 
-        // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + DESCRIPTION_DESC_BOB,
-                expectedMessage);
+                // missing phone prefix
+                assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
 
-        // missing description prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_DESCRIPTION_BOB,
-                expectedMessage);
+                // missing description prefix
+                assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_DESCRIPTION_BOB, expectedMessage);
 
-        // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_DESCRIPTION_BOB,
-                expectedMessage);
-    }
+                // all prefixes missing
+                assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_DESCRIPTION_BOB, expectedMessage);
+        }
 
-    @Test
-    public void parse_invalidValue_failure() {
-        // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+        @Test
+        public void parse_invalidValue_failure() {
+                // invalid name
+                assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND
+                                + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
 
-        // invalid phone
-        assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + DESCRIPTION_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                // invalid phone
+                assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND
+                                + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
 
-        // invalid description
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Description.MESSAGE_CONSTRAINTS);
+                // invalid description
+                assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC + TAG_DESC_HUSBAND
+                                + TAG_DESC_FRIEND, Description.MESSAGE_CONSTRAINTS);
 
-        // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                // invalid tag
+                assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + INVALID_TAG_DESC
+                                + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
 
-        // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC,
-                Name.MESSAGE_CONSTRAINTS);
+                // two invalid values, only first invalid value reported
+                assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC,
+                                Name.MESSAGE_CONSTRAINTS);
 
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB
-                + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-    }
+                // non-empty preamble
+                assertParseFailure(parser,
+                                PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB
+                                                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateVendorCommand.MESSAGE_USAGE));
+        }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -36,8 +36,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_add() throws Exception {
         Vendor vendor = new VendorBuilder().build();
-        AddCommand command = (AddCommand) parser.parseCommand(VendorUtil.getAddCommand(vendor));
-        assertEquals(new AddCommand(vendor), command);
+        CreateVendorCommand command = (CreateVendorCommand) parser.parseCommand(VendorUtil.getAddCommand(vendor));
+        assertEquals(new CreateVendorCommand(vendor), command);
     }
 
     @Test
@@ -48,8 +48,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_delete() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_VENDOR.getOneBased());
+        DeleteCommand command = (DeleteCommand) parser
+                .parseCommand(DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_VENDOR.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_VENDOR), command);
     }
 
@@ -71,8 +71,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        FindCommand command = (FindCommand) parser
+                .parseCommand(FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
@@ -90,8 +90,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
+                () -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -13,8 +13,8 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditVendorDescriptor;
@@ -90,8 +90,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
-                () -> parser.parseCommand(""));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
+             -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/VendorUtil.java
+++ b/src/test/java/seedu/address/testutil/VendorUtil.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
 
-import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.commands.EditCommand.EditVendorDescriptor;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.vendor.Vendor;
@@ -21,7 +21,7 @@ public class VendorUtil {
      * Returns an add command string for adding the {@code vendor}.
      */
     public static String getAddCommand(Vendor vendor) {
-        return AddCommand.COMMAND_WORD + " " + getVendorDetails(vendor);
+        return CreateVendorCommand.COMMAND_WORD + " " + getVendorDetails(vendor);
     }
 
     /**
@@ -32,8 +32,7 @@ public class VendorUtil {
         sb.append(PREFIX_NAME + vendor.getName().fullName + " ");
         sb.append(PREFIX_PHONE + vendor.getPhone().value + " ");
         sb.append(PREFIX_DESCRIPTION + vendor.getDescription().value + " ");
-        vendor.getTags().stream().forEach(
-                s -> sb.append(PREFIX_TAG + s.tagName + " "));
+        vendor.getTags().stream().forEach(s -> sb.append(PREFIX_TAG + s.tagName + " "));
         return sb.toString();
     }
 


### PR DESCRIPTION
# Summary

- Change `AddCommand` and `AddCommandParser` to be `CreateVendorCommand` and `CreateVendorCommandParser`
- Change description prefix to be `d/`
- Change `CreateVendorCommand` command to be `create_vendor` 
- Change messages related to `create_vendor`