### PR TITLE
Add parser support for adding new events

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CreateEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateEventCommand.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.event.Event;
+
+public class CreateEventCommand extends Command {
+    public static final String COMMAND_WORD = "create_event";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a new event in the address book. "
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_DATE + "DATE";
+
+    public static final String MESSAGE_SUCCESS = "New event created: %1$s";
+    public static final String MESSAGE_DUPLICATE_VENDOR = "This event already exists in the address book";
+    public static final String MESSAGE_INVALID_DATE = "Date specified is invalid";
+    public static final String MESSAGE_EMPTY_NAME = "Cannot create event without a name";
+    public static final String MESSAGE_INVALID_NAME = "Cannot create event with invalid name";
+    public static final String MESSAGE_UNIMPLEMENTED = "CreateEventCommand is unimplemented";
+
+    private final Event toAdd;
+
+    /**
+     * Creates a CreateEventCommand to add the specified {@code Event}
+     */
+    public CreateEventCommand(Event event) {
+        requireNonNull(event);
+        toAdd = event;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException(MESSAGE_UNIMPLEMENTED);
+
+        // TODO validation checks for event
+        // TODO add event to model
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CreateEventCommand)) {
+            return false;
+        }
+
+        CreateEventCommand otherCreateEventCommand = (CreateEventCommand) other;
+        return toAdd.equals(otherCreateEventCommand.toAdd);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("toAdd", toAdd)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CreateEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateEventCommand.java
@@ -9,6 +9,9 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
 
+/**
+ * Creates an event in the address book.
+ */
 public class CreateEventCommand extends Command {
     public static final String COMMAND_WORD = "create_event";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CreateEventCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case CreateEventCommand.COMMAND_WORD:
+            return new CreateEventCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_DATE = new Prefix("d/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,6 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_DATE = new Prefix("d/");
+    public static final Prefix PREFIX_DATE = new Prefix("on/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CreateEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateEventCommandParser.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.parser;public class CreateEventCommandParser {
+}

--- a/src/main/java/seedu/address/logic/parser/CreateEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateEventCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.CreateEventCommand;
@@ -11,6 +12,9 @@ import seedu.address.model.event.Date;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.Name;
 
+/**
+ * Parses input arguments and creates a new CreateEventCommand object
+ */
 public class CreateEventCommandParser implements Parser<CreateEventCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the CreateEventCommand

--- a/src/main/java/seedu/address/logic/parser/CreateEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateEventCommandParser.java
@@ -1,2 +1,46 @@
-package seedu.address.logic.parser;public class CreateEventCommandParser {
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.CreateEventCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.event.Date;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.Name;
+
+public class CreateEventCommandParser implements Parser<CreateEventCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the CreateEventCommand
+     * and returns an CreateEventCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CreateEventCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DATE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_DATE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateEventCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_DATE);
+        Name name = ParserUtil.parseEventName(argMultimap.getValue(PREFIX_NAME).get());
+        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+
+        Event event = new Event(name, date);
+
+        return new CreateEventCommand(event);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values
+     * in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.event.Date;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.vendor.Description;
 import seedu.address.model.vendor.Name;
@@ -51,6 +52,23 @@ public class ParserUtil {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
         return new Name(trimmedName);
+    }
+
+    /**
+     * Parses a {@code String name} into a {@code seedu.address.model.event.Name}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid.
+     */
+    public static seedu.address.model.event.Name parseEventName(String name) throws ParseException {
+        requireNonNull(name);
+        String trimmedName = name.trim();
+        if (!seedu.address.model.event.Name.isValidName(trimmedName)) {
+            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+        }
+        // unable to import event.Name directly due to clashing names
+        // TODO modify after name clash is resolved
+        return new seedu.address.model.event.Name(trimmedName);
     }
 
     /**
@@ -108,5 +126,20 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String date} into a {@code Date}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code date} is invalid.
+     */
+    public static Date parseDate(String date) throws ParseException {
+        requireNonNull(date);
+        String trimmedDate = date.trim();
+        if (!Date.isValidDate(trimmedDate)) {
+            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+        }
+        return new Date(date);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -140,6 +140,6 @@ public class ParserUtil {
         if (!Date.isValidDate(trimmedDate)) {
             throw new ParseException(Date.MESSAGE_CONSTRAINTS);
         }
-        return new Date(date);
+        return new Date(trimmedDate);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CreateEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateEventCommandTest.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalVendors.ALICE;
+import static seedu.address.testutil.TypicalVendors.getTypicalAddressBook;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.event.Date;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.Name;
+import seedu.address.model.vendor.Vendor;
+import seedu.address.testutil.VendorBuilder;
+
+public class CreateEventCommandTest {
+    private Event excursionEvent = new Event(new Name("Zoo Excursion"), new Date("2024-10-10"));
+    private Event partyEvent = new Event(new Name("Birthday Party"), new Date("2023-12-30"));
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    @Test
+    public void constructor_nullEvent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new CreateEventCommand(null));
+    }
+
+    @Test
+    public void execute_commandUnimplemented_throwsCommandException() {
+        assertThrows(CommandException.class, () -> new CreateEventCommand(excursionEvent).execute(model));
+    }
+
+    @Test
+    public void equals() {
+        CreateEventCommand addExcursionCommand = new CreateEventCommand(excursionEvent);
+        CreateEventCommand addPartyCommand = new CreateEventCommand(partyEvent);
+
+        // same object -> returns true
+        assertTrue(addExcursionCommand.equals(addExcursionCommand));
+
+        // same values -> returns true
+        CreateEventCommand addPartyCommandCopy = new CreateEventCommand(partyEvent);
+        assertTrue(addPartyCommand.equals(addPartyCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addExcursionCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addExcursionCommand.equals(null));
+
+        // different vendor -> returns false
+        assertFalse(addExcursionCommand.equals(addPartyCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        CreateEventCommand createEventCommand = new CreateEventCommand(excursionEvent);
+        String expected = CreateEventCommand.class.getCanonicalName() + "{toAdd=" + excursionEvent + "}";
+        assertEquals(expected, createEventCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CreateEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateEventCommandTest.java
@@ -4,13 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalVendors.ALICE;
 import static seedu.address.testutil.TypicalVendors.getTypicalAddressBook;
 
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
-import seedu.address.logic.Messages;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -18,8 +15,6 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.event.Date;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.Name;
-import seedu.address.model.vendor.Vendor;
-import seedu.address.testutil.VendorBuilder;
 
 public class CreateEventCommandTest {
     private Event excursionEvent = new Event(new Name("Zoo Excursion"), new Date("2024-10-10"));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -48,7 +48,7 @@ public class AddressBookParserTest {
     public void parseCommand_createEvent() throws Exception {
         Event partyEvent = new Event(new Name("Party"), new Date("2024-10-10"));
         CreateEventCommand command = (CreateEventCommand) parser
-                .parseCommand("create_event n/Party d/2024-10-10");
+                .parseCommand("create_event n/Party on/2024-10-10");
         assertEquals(new CreateEventCommand(partyEvent), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.CreateEventCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditVendorDescriptor;
@@ -23,6 +24,9 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.event.Date;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.Name;
 import seedu.address.model.vendor.NameContainsKeywordsPredicate;
 import seedu.address.model.vendor.Vendor;
 import seedu.address.testutil.EditVendorDescriptorBuilder;
@@ -38,6 +42,14 @@ public class AddressBookParserTest {
         Vendor vendor = new VendorBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(VendorUtil.getAddCommand(vendor));
         assertEquals(new AddCommand(vendor), command);
+    }
+
+    @Test
+    public void parseCommand_createEvent() throws Exception {
+        Event partyEvent = new Event(new Name("Party"), new Date("2024-10-10"));
+        CreateEventCommand command = (CreateEventCommand) parser
+                .parseCommand("create_event n/Party d/2024-10-10");
+        assertEquals(new CreateEventCommand(partyEvent), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/CreateEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateEventCommandParserTest.java
@@ -26,8 +26,9 @@ public class CreateEventCommandParserTest {
         Event expectedEvent = excursionEvent;
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE
-                + "2024-10-10", new CreateEventCommand(expectedEvent));
+        assertParseSuccess(parser,
+                PREAMBLE_WHITESPACE + " " + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE + "2024-10-10",
+                new CreateEventCommand(expectedEvent));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/CreateEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateEventCommandParserTest.java
@@ -9,10 +9,12 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.CreateEventCommand;
 import seedu.address.model.event.Date;
-import seedu.address.model.event.Name;
 import seedu.address.model.event.Event;
+import seedu.address.model.event.Name;
+
 
 public class CreateEventCommandParserTest {
 
@@ -60,8 +62,8 @@ public class CreateEventCommandParserTest {
                 + "10 October 2024", Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + PREFIX_NAME + "Zoo Excursion" + " " +
-                        PREFIX_DATE + "10 October 2024",
+        assertParseFailure(parser,
+                PREAMBLE_NON_EMPTY + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE + "10 October 2024",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateEventCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/CreateEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateEventCommandParserTest.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.CreateEventCommand;
+import seedu.address.model.event.Date;
+import seedu.address.model.event.Name;
+import seedu.address.model.event.Event;
+
+public class CreateEventCommandParserTest {
+
+    private CreateEventCommandParser parser = new CreateEventCommandParser();
+    private Event excursionEvent = new Event(new Name("Zoo Excursion"), new Date("2024-10-10"));
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Event expectedEvent = excursionEvent;
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE
+                + "2024-10-10", new CreateEventCommand(expectedEvent));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateEventCommand.MESSAGE_USAGE);
+
+        // missing name prefix
+        assertParseFailure(parser, "Zoo Excursion" + " " + PREFIX_DATE + "2024-10-10",
+                expectedMessage);
+
+        // missing date prefix
+        assertParseFailure(parser, PREFIX_NAME + "Zoo Excursion" + " " + "2024-10-10",
+                expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, "Zoo Excursion" + " " + "2024-10-10",
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, " " + PREFIX_NAME + "Zoo Excursion?" + " " + PREFIX_DATE + "2024-10-10",
+                Name.MESSAGE_CONSTRAINTS);
+
+        // invalid date
+        assertParseFailure(parser, " " + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE + "10 October 2024",
+                Date.MESSAGE_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, " " + PREFIX_NAME + "Zoo Excursion?" + " " + PREFIX_DATE
+                + "10 October 2024", Name.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + PREFIX_NAME + "Zoo Excursion" + " " +
+                        PREFIX_DATE + "10 October 2024",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateEventCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.event.Date;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.vendor.Description;
 import seedu.address.model.vendor.Name;
@@ -21,15 +22,19 @@ import seedu.address.model.vendor.Phone;
 
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_EVENT_NAME = "Zoo?";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_DESCRIPTION = " ";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_DATE = "10 October 2024";
 
     private static final String VALID_NAME = "Rachel Walker";
+    private static final String VALID_EVENT_NAME = "Zoo Excursion";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_DESCRIPTION = "123 Main Street #0505";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_DATE = "2024-10-10";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -74,6 +79,29 @@ public class ParserUtilTest {
         String nameWithWhitespace = WHITESPACE + VALID_NAME + WHITESPACE;
         Name expectedName = new Name(VALID_NAME);
         assertEquals(expectedName, ParserUtil.parseName(nameWithWhitespace));
+    }
+
+    @Test
+    public void parseEventName_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseEventName(null));
+    }
+
+    @Test
+    public void parseEventName_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseEventName(INVALID_EVENT_NAME));
+    }
+
+    @Test
+    public void parseEventName_validValueWithoutWhitespace_returnsEventName() throws Exception {
+        seedu.address.model.event.Name expectedName = new seedu.address.model.event.Name(VALID_EVENT_NAME);
+        assertEquals(expectedName, ParserUtil.parseEventName(VALID_EVENT_NAME));
+    }
+
+    @Test
+    public void parseEventName_validValueWithWhitespace_returnsTrimmedEventName() throws Exception {
+        String nameWithWhitespace = WHITESPACE + VALID_EVENT_NAME + WHITESPACE;
+        seedu.address.model.event.Name expectedName = new seedu.address.model.event.Name(VALID_EVENT_NAME);
+        assertEquals(expectedName, ParserUtil.parseEventName(nameWithWhitespace));
     }
 
     @Test
@@ -166,5 +194,28 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseDate_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDate(null));
+    }
+
+    @Test
+    public void parseDate_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDate(INVALID_DATE));
+    }
+
+    @Test
+    public void parseDate_validValueWithoutWhitespace_returnsDate() throws Exception {
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(VALID_DATE));
+    }
+
+    @Test
+    public void parseDate_validValueWithWhitespace_returnsTrimmedDate() throws Exception {
+        String dateWithWhitespace = WHITESPACE + VALID_DATE + WHITESPACE;
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(dateWithWhitespace));
     }
 }


### PR DESCRIPTION
Resolves #62 and #76

Test cases are currently hardcoded. Will need to be refactored to use utility classes later on.
- Add `CreateEventCommand` and `CreateEventCommandParser`
- Add a new prefix for date, prefix is `on/`
- Command to add an event is `create_event`
- Add case to handle `create_event`
- Added new test cases and updated existing test cases