### PR TITLE
Implement UniqueEventList for parent model

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.UniqueEventList;
 import seedu.address.model.vendor.UniqueVendorList;
 import seedu.address.model.vendor.Vendor;
 
@@ -16,6 +18,7 @@ import seedu.address.model.vendor.Vendor;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniqueVendorList vendors;
+    private final UniqueEventList events;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -26,6 +29,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         vendors = new UniqueVendorList();
+        events = new UniqueEventList();
     }
 
     public AddressBook() {}
@@ -49,12 +53,21 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the contents of the event list with {@code events}.
+     * {@code events} must not contain duplicate events.
+     */
+    public void setEvents(List<Event> events) {
+        this.events.setEvents(events);
+    }
+
+    /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
 
         setVendors(newData.getVendorList());
+        setEvents(newData.getEventList());
     }
 
     //// vendor-level operations
@@ -86,12 +99,32 @@ public class AddressBook implements ReadOnlyAddressBook {
         vendors.setVendor(target, editedVendor);
     }
 
+    //// event-level operations
+
+    /**
+     * Returns true if a event with the same identity as {@code event} exists in the address book.
+     */
+    public boolean hasEvent(Event event) {
+        requireNonNull(event);
+        return events.contains(event);
+    }
+
+    /**
+     * Adds an event to the address book.
+     * The event must not already exist in the address book.
+     */
+    public void addEvent(Event event) {
+        events.add(event);
+    }
+
+    // TODO add method to update existing Event with new Event object
+
     /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
      */
-    public void removeVendor(Vendor key) {
-        vendors.remove(key);
+    public void removeEvent(Event key) {
+        events.remove(key);
     }
 
     //// util methods
@@ -107,6 +140,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     public ObservableList<Vendor> getVendorList() {
         return vendors.asUnmodifiableObservableList();
     }
+
+    @Override
+    public ObservableList<Event> getEventList() { return events.asUnmodifiableObservableList(); }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
@@ -164,11 +165,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         }
 
         AddressBook otherAddressBook = (AddressBook) other;
-        return vendors.equals(otherAddressBook.vendors);
+        return vendors.equals(otherAddressBook.vendors) && events.equals(otherAddressBook.events);
     }
 
     @Override
     public int hashCode() {
-        return vendors.hashCode();
+        return Objects.hash(vendors.hashCode(), events.hashCode());
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -99,6 +99,14 @@ public class AddressBook implements ReadOnlyAddressBook {
         vendors.setVendor(target, editedVendor);
     }
 
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeVendor(Vendor key) {
+        vendors.remove(key);
+    }
+
     //// event-level operations
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -151,7 +151,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public ObservableList<Event> getEventList() { return events.asUnmodifiableObservableList(); }
+    public ObservableList<Event> getEventList() {
+        return events.asUnmodifiableObservableList();
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -142,6 +142,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     public String toString() {
         return new ToStringBuilder(this)
                 .add("vendors", vendors)
+                .add("events", events)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -107,4 +107,7 @@ public interface Model {
      * {@code event} must not already exist in the address book.
      */
     void addEvent(Event event);
+
+    /** Returns an unmodifiable view of the filtered event list */
+    ObservableList<Event> getFilteredEventList();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 
 /**
@@ -88,4 +89,22 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredVendorList(Predicate<Vendor> predicate);
+
+    /**
+     * Returns true if an event with the same identity as {@code event} exists in
+     * the address book.
+     */
+    boolean hasEvent(Event event);
+
+    /**
+     * Deletes the given event.
+     * The event must exist in the address book.
+     */
+    void deleteEvent(Event target);
+
+    /**
+     * Adds the given event.
+     * {@code event} must not already exist in the address book.
+     */
+    void addEvent(Event event);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -23,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Vendor> filteredVendors;
+    private final FilteredList<Event> filteredEvents;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -35,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredVendors = new FilteredList<>(this.addressBook.getVendorList());
+        filteredEvents = new FilteredList<>(this.addressBook.getEventList());
     }
 
     public ModelManager() {
@@ -143,6 +145,17 @@ public class ModelManager implements Model {
     public void updateFilteredVendorList(Predicate<Vendor> predicate) {
         requireNonNull(predicate);
         filteredVendors.setPredicate(predicate);
+    }
+
+    //=========== Filtered Event List Accessors =============================================================
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Event} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Event> getFilteredEventList() {
+        return filteredEvents;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 
 /**
@@ -109,6 +110,22 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedVendor);
 
         addressBook.setVendor(target, editedVendor);
+    }
+
+    @Override
+    public boolean hasEvent(Event event) {
+        requireNonNull(event);
+        return addressBook.hasEvent(event);
+    }
+
+    @Override
+    public void deleteEvent(Event target) {
+        addressBook.removeEvent(target);
+    }
+
+    @Override
+    public void addEvent(Event event) {
+        addressBook.addEvent(event);
     }
 
     //=========== Filtered Vendor List Accessors =============================================================

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 
 /**
@@ -13,5 +14,11 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate vendors.
      */
     ObservableList<Vendor> getVendorList();
+
+    /**
+     * Returns an unmodifiable view of the events list.
+     * This list will not contain any duplicate events.
+     */
+    ObservableList<Event> getEventList();
 
 }

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -3,6 +3,7 @@ package seedu.address.model.event;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.vendor.Vendor;
 
 /**
  * Represents an Event in EventTory.
@@ -30,6 +31,19 @@ public class Event {
 
     public Date getDate() {
         return date;
+    }
+
+    /**
+     * Returns true if both events have the same name.
+     * This defines a weaker notion of equality between two events.
+     */
+    public boolean isSameEvent(Event otherEvent) {
+        if (otherEvent == this) {
+            return true;
+        }
+
+        return otherEvent != null
+                && otherEvent.getName().equals(getName());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -3,7 +3,6 @@ package seedu.address.model.event;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.vendor.Vendor;
 
 /**
  * Represents an Event in EventTory.

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -1,0 +1,2 @@
+package seedu.address.model.event;public class UniqueEventList {
+}

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -1,2 +1,115 @@
-package seedu.address.model.event;public class UniqueEventList {
+package seedu.address.model.event;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.event.exceptions.DuplicateEventException;
+import seedu.address.model.event.exceptions.EventNotFoundException;
+
+public class UniqueEventList implements Iterable<Event> {
+    private final ObservableList<Event> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Event> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent event as the given argument.
+     */
+    public boolean contains(Event toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameEvent);
+    }
+
+    /**
+     * Adds an Event to the list.
+     * The event must not already exist in the list.
+     */
+    public void add(Event toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateEventException();
+        }
+        internalList.add(toAdd);
+    }
+
+    // TODO add method to handle editing Events, not needed for MVP
+
+    /**
+     * Removes the equivalent event from the list.
+     * The event must exist in the list.
+     */
+    public void remove(Event toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new EventNotFoundException();
+        }
+    }
+
+    /**
+     * Replaces the contents of this list with {@code vendors}.
+     * {@code vendors} must not contain duplicate vendors.
+     */
+    public void setEvents(List<Event> events) {
+        requireAllNonNull(events);
+        if (!eventsAreUnique(events)) {
+            throw new DuplicateEventException();
+        }
+
+        internalList.setAll(events);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Event> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Event> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UniqueEventList)) {
+            return false;
+        }
+
+        UniqueEventList otherUniqueEventList = (UniqueEventList) other;
+        return internalList.equals(otherUniqueEventList.internalList);
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return internalList.toString();
+    }
+
+    /**
+     * Returns true if {@code events} contains only unique events.
+     */
+    private boolean eventsAreUnique(List<Event> events) {
+        for (int i = 0; i < events.size() - 1; i++) {
+            for (int j = i + 1; j < events.size(); j++) {
+                if (events.get(i).isSameEvent(events.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 }

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -49,6 +49,11 @@ public class UniqueEventList implements Iterable<Event> {
         }
     }
 
+    public void setEvents(UniqueEventList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
     /**
      * Replaces the contents of this list with {@code vendors}.
      * {@code vendors} must not contain duplicate vendors.

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -11,6 +11,23 @@ import javafx.collections.ObservableList;
 import seedu.address.model.event.exceptions.DuplicateEventException;
 import seedu.address.model.event.exceptions.EventNotFoundException;
 
+/**
+ * A list of events that enforces uniqueness between its elements and does not allow nulls.
+ * <p>
+ * An event is considered unique by comparing using {@code Event#isSameEvent(Event)}. As such, adding and updating of
+ * events uses Event#isSameEvent(Event) for equality to ensure that the event being added or updated is
+ * unique in terms of identity in the UniqueEventList.
+ * </p>
+ * <p>
+ * However, the removal of a event uses Event#equals(Object) to
+ * ensure that the event with exactly the same fields will be removed.
+ * </p>
+ * <p>
+ * Supports a minimal set of list operations.
+ * </p>
+ *
+ * @see Event#isSameEvent(Event)
+ */
 public class UniqueEventList implements Iterable<Event> {
     private final ObservableList<Event> internalList = FXCollections.observableArrayList();
     private final ObservableList<Event> internalUnmodifiableList =

--- a/src/main/java/seedu/address/model/event/exceptions/DuplicateEventException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/DuplicateEventException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.event.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Events (Events are considered duplicates if they have the same
+ * identity).
+ */
+public class DuplicateEventException extends RuntimeException {
+    public DuplicateEventException() {
+        super("Operation would result in duplicate events");
+    }
+}
+

--- a/src/main/java/seedu/address/model/event/exceptions/EventNotFoundException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/EventNotFoundException.java
@@ -1,0 +1,4 @@
+package seedu.address.model.event.exceptions;
+
+public class EventNotFoundException extends RuntimeException {
+}

--- a/src/main/java/seedu/address/model/event/exceptions/EventNotFoundException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/EventNotFoundException.java
@@ -1,4 +1,7 @@
 package seedu.address.model.event.exceptions;
 
+/**
+ * Signals that the operation is unable to find the specified event.
+ */
 public class EventNotFoundException extends RuntimeException {
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -174,6 +174,11 @@ public class AddCommandTest {
         public void updateFilteredVendorList(Predicate<Vendor> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public ObservableList<Event> getFilteredEventList() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 import seedu.address.testutil.VendorBuilder;
 
@@ -145,6 +146,21 @@ public class AddCommandTest {
 
         @Override
         public void setVendor(Vendor target, Vendor editedVendor) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasEvent(Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addEvent(Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteEvent(Event target) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -31,7 +31,6 @@ public class AddressBookTest {
     private final AddressBook addressBook = new AddressBook();
     private final Event testEvent = new Event(new Name("Test Event"), new Date("2024-10-11"));
     private final Event similarTestEvent = new Event(new Name("Test Event"), new Date("2023-05-20"));
-    private final Event differentEvent = new Event(new Name("Different"), new Date("2020-06-01"));
 
     @Test
     public void constructor() {

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -108,7 +108,9 @@ public class AddressBookTest {
         }
 
         @Override
-        public ObservableList<Event> getEventList() { return events; }
+        public ObservableList<Event> getEventList() {
+            return events;
+        }
     }
 
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -18,7 +18,9 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.event.Date;
 import seedu.address.model.event.Event;
+import seedu.address.model.event.Name;
 import seedu.address.model.vendor.Vendor;
 import seedu.address.model.vendor.exceptions.DuplicateVendorException;
 import seedu.address.testutil.VendorBuilder;
@@ -26,6 +28,9 @@ import seedu.address.testutil.VendorBuilder;
 public class AddressBookTest {
 
     private final AddressBook addressBook = new AddressBook();
+    private final Event testEvent = new Event(new Name("Test Event"), new Date("2024-10-11"));
+    private final Event similarTestEvent = new Event(new Name("Test Event"), new Date("2023-05-20"));
+    private final Event differentEvent = new Event(new Name("Different"), new Date("2020-06-01"));
 
     @Test
     public void constructor() {
@@ -80,13 +85,43 @@ public class AddressBookTest {
     }
 
     @Test
+    public void hasEvent_nullEvent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.hasEvent(null));
+    }
+
+    @Test
+    public void hasEvent_eventNotInAddressBook_returnsFalse() {
+        assertFalse(addressBook.hasEvent(testEvent));
+    }
+
+    @Test
+    public void hasEvent_eventInAddressBook_returnsTrue() {
+        addressBook.addEvent(testEvent);
+        assertTrue(addressBook.hasEvent(testEvent));
+    }
+
+    @Test
+    public void hasEvent_eventWithSameIdentityFieldsInAddressBook_returnsTrue() {
+        addressBook.addEvent(testEvent);
+        assertTrue(addressBook.hasEvent(similarTestEvent));
+    }
+
+    @Test
     public void getVendorList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getVendorList().remove(0));
     }
 
     @Test
+    public void getEventList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> addressBook.getEventList().remove(0));
+    }
+
+    @Test
     public void toStringMethod() {
-        String expected = AddressBook.class.getCanonicalName() + "{vendors=" + addressBook.getVendorList() + "}";
+        String expected = AddressBook.class.getCanonicalName()
+                + "{vendors=" + addressBook.getVendorList() + ", "
+                + "events=" + addressBook.getEventList()
+                + "}";
         assertEquals(expected, addressBook.toString());
     }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 import seedu.address.model.vendor.exceptions.DuplicateVendorException;
 import seedu.address.testutil.VendorBuilder;
@@ -95,6 +96,7 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Vendor> vendors = FXCollections.observableArrayList();
+        private final ObservableList<Event> events = FXCollections.observableArrayList();
 
         AddressBookStub(Collection<Vendor> vendors) {
             this.vendors.setAll(vendors);
@@ -104,6 +106,9 @@ public class AddressBookTest {
         public ObservableList<Vendor> getVendorList() {
             return vendors;
         }
+
+        @Override
+        public ObservableList<Event> getEventList() { return events; }
     }
 
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -21,6 +21,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.event.Date;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.Name;
+import seedu.address.model.event.exceptions.DuplicateEventException;
 import seedu.address.model.vendor.Vendor;
 import seedu.address.model.vendor.exceptions.DuplicateVendorException;
 import seedu.address.testutil.VendorBuilder;
@@ -104,6 +105,26 @@ public class AddressBookTest {
     public void hasEvent_eventWithSameIdentityFieldsInAddressBook_returnsTrue() {
         addressBook.addEvent(testEvent);
         assertTrue(addressBook.hasEvent(similarTestEvent));
+    }
+
+    // might be redundant has this is already tested in UniqueEventListTest.java
+    @Test
+    public void addEvent_nullEvent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.addEvent(null));
+    }
+
+    // might be redundant has this is already tested in UniqueEventListTest.java
+    @Test
+    public void addEvent_eventInAddressBook_throwsDuplicateEventException() {
+        addressBook.addEvent(testEvent);
+        assertThrows(DuplicateEventException.class, () -> addressBook.addEvent(testEvent));
+    }
+
+    // might be redundant has this is already tested in UniqueEventListTest.java
+    @Test
+    public void addEvent_eventWithSameIdentityFieldsInAddressBook_throwsDuplicateEventException() {
+        addressBook.addEvent(testEvent);
+        assertThrows(DuplicateEventException.class, () -> addressBook.addEvent(testEvent));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -15,12 +15,16 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.event.Date;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.Name;
 import seedu.address.model.vendor.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
 
     private ModelManager modelManager = new ModelManager();
+    private final Event testEvent = new Event(new Name("Test Event"), new Date("2024-10-11"));
 
     @Test
     public void constructor() {
@@ -86,6 +90,22 @@ public class ModelManagerTest {
     public void hasVendor_vendorInAddressBook_returnsTrue() {
         modelManager.addVendor(ALICE);
         assertTrue(modelManager.hasVendor(ALICE));
+    }
+
+    @Test
+    public void hasEvent_nullEvent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasEvent(null));
+    }
+
+    @Test
+    public void hasEvent_eventNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasEvent(testEvent));
+    }
+
+    @Test
+    public void hasEvent_eventInAddressBook_returnsTrue() {
+        modelManager.addEvent(testEvent);
+        assertTrue(modelManager.hasEvent(testEvent));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -114,6 +114,11 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void getFilteredEventList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredEventList().remove(0));
+    }
+
+    @Test
     public void equals() {
         AddressBook addressBook = new AddressBookBuilder().withVendor(ALICE).withVendor(BENSON).build();
         AddressBook differentAddressBook = new AddressBook();

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -9,6 +9,10 @@ import org.junit.jupiter.api.Test;
 
 public class EventTest {
 
+    private final Event testEvent = new Event(new Name("Test Event"), new Date("2024-10-11"));
+    private final Event similarTestEvent = new Event(new Name("Test Event"), new Date("2023-05-20"));
+    private final Event differentEvent = new Event(new Name("Different"), new Date("2020-06-01"));
+
     @Test
     public void constructor_nullValues_throwsNullPointerException() {
         Name name = new Name("Meeting");
@@ -29,6 +33,26 @@ public class EventTest {
         // Validate that the Event object is created with the correct values
         assertEquals(name, event.getName());
         assertEquals(date, event.getDate());
+    }
+
+    @Test
+    public void isSameEvent_nullEvent_returnsFalse() {
+        assertFalse(testEvent.isSameEvent(null));
+    }
+
+    @Test
+    public void isSameEvent_sameEvent_returnsTrue() {
+        assertTrue(testEvent.isSameEvent(testEvent));
+    }
+
+    @Test
+    public void isSameEvent_differentEvent_returnsFalse() {
+        assertFalse(testEvent.isSameEvent(differentEvent));
+    }
+
+    @Test
+    public void isSameEvent_eventWithSameIdentity_returnsTrue() {
+        assertTrue(testEvent.isSameEvent(similarTestEvent));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/event/UniqueEventListTest.java
+++ b/src/test/java/seedu/address/model/event/UniqueEventListTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.model.event.exceptions.DuplicateEventException;
 import seedu.address.model.event.exceptions.EventNotFoundException;
 

--- a/src/test/java/seedu/address/model/event/UniqueEventListTest.java
+++ b/src/test/java/seedu/address/model/event/UniqueEventListTest.java
@@ -1,0 +1,2 @@
+package seedu.address.model.event;public class UniqueEventListTest {
+}

--- a/src/test/java/seedu/address/model/event/UniqueEventListTest.java
+++ b/src/test/java/seedu/address/model/event/UniqueEventListTest.java
@@ -1,2 +1,117 @@
-package seedu.address.model.event;public class UniqueEventListTest {
+package seedu.address.model.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.model.event.exceptions.DuplicateEventException;
+import seedu.address.model.event.exceptions.EventNotFoundException;
+
+public class UniqueEventListTest {
+    private final UniqueEventList uniqueEventList = new UniqueEventList();
+    private final Event testEvent = new Event(new Name("Test Event"), new Date("2024-10-11"));
+    private final Event similarTestEvent = new Event(new Name("Test Event"), new Date("2023-05-20"));
+    private final Event differentEvent = new Event(new Name("Different"), new Date("2020-06-01"));
+
+    @Test
+    public void contains_nullEvent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueEventList.contains(null));
+    }
+
+    @Test
+    public void contains_eventNotInList_returnsFalse() {
+        assertFalse(uniqueEventList.contains(testEvent));
+    }
+
+    @Test
+    public void contains_eventInList_returnsTrue() {
+        uniqueEventList.add(testEvent);
+        assertTrue(uniqueEventList.contains(testEvent));
+    }
+
+    @Test
+    public void contains_eventWithSameIdentityFieldsInList_returnsTrue() {
+        uniqueEventList.add(testEvent);
+        assertTrue(uniqueEventList.contains(similarTestEvent));
+    }
+
+    @Test
+    public void add_nullEvent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueEventList.add(null));
+    }
+
+    @Test
+    public void add_duplicateEvent_throwsDuplicateEventException() {
+        uniqueEventList.add(testEvent);
+        assertThrows(DuplicateEventException.class, () -> uniqueEventList.add(testEvent));
+    }
+
+    @Test
+    public void remove_nullEvent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueEventList.remove(null));
+    }
+
+    @Test
+    public void remove_eventDoesNotExist_throwsEventNotFoundException() {
+        assertThrows(EventNotFoundException.class, () -> uniqueEventList.remove(testEvent));
+    }
+
+    @Test
+    public void remove_existingEvent_removesEvent() {
+        uniqueEventList.add(testEvent);
+        uniqueEventList.remove(testEvent);
+        UniqueEventList expectedUniqueEventList = new UniqueEventList();
+        assertEquals(expectedUniqueEventList, uniqueEventList);
+    }
+
+    @Test
+    public void setEvents_nullUniqueEventList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueEventList.setEvents((UniqueEventList) null));
+    }
+
+    @Test
+    public void setEvents_uniqueEventList_replacesOwnListWithProvidedUniqueEventList() {
+        uniqueEventList.add(testEvent);
+        UniqueEventList expectedUniqueEventList = new UniqueEventList();
+        expectedUniqueEventList.add(differentEvent);
+        uniqueEventList.setEvents(expectedUniqueEventList);
+        assertEquals(expectedUniqueEventList, uniqueEventList);
+    }
+
+    @Test
+    public void setEvents_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueEventList.setEvents((List<Event>) null));
+    }
+
+    @Test
+    public void setEvents_list_replacesOwnListWithProvidedList() {
+        uniqueEventList.add(testEvent);
+        List<Event> eventList = List.of(differentEvent);
+        uniqueEventList.setEvents(eventList);
+        UniqueEventList expectedUniqueEventList = new UniqueEventList();
+        expectedUniqueEventList.add(differentEvent);
+        assertEquals(expectedUniqueEventList, uniqueEventList);
+    }
+
+    @Test
+    public void setEvents_listWithDuplicateEvents_throwsDuplicateEventException() {
+        List<Event> listWithDuplicateEvents = Arrays.asList(testEvent, testEvent);
+        assertThrows(DuplicateEventException.class, () -> uniqueEventList.setEvents(listWithDuplicateEvents));
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+                -> uniqueEventList.asUnmodifiableObservableList().remove(0));
+    }
+
+    @Test
+    public void toStringMethod() {
+        assertEquals(uniqueEventList.asUnmodifiableObservableList().toString(), uniqueEventList.toString());
+    }
 }


### PR DESCRIPTION
Resolves #75 

### Changes
- Add `isSameEvent` method to `Event` class
- Add `UniqueEventList` to mirror functionality of `UniqueVendorList`
- Add exceptions for handling event operations
- Modified interfaces `Model` and `ReadOnlyAddressBook`
- Update `ModelManager` and `AddressBook` to store events, as well as implement methods that operate on events (from their updated interfaces)
- Update existing `ModelStub` and `AddressBookStub` used in `AddCommandTest` and `AddressBookTest` respectively
- Add basic tests for `UniqueEventList`

### Tests
No new tests were added to cover the new functionality of `ModelManager` and `AddressBook`. The test coverage will decrease, but I think it'll be more efficient to add said tests after the util classes for event testing have been added. :)

### Note
- The current `CreateEventCommand` is still non-functional and none of the new methods added to `ModelManager` and `AddressBook` are in use yet.
- Only the model has been updated. The storage component has not been updated to store Events in JSON yet.