### PR TITLE
Reworked current delete command for vendor delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,25 @@
-# Gradle build files
-/.gradle/
-/build/
-src/main/resources/docs/
-
 # IDEA files
 /.idea/
 /out/
 /*.iml
 
-# Storage/log files
-/data/
-/config.json
-/preferences.json
-/*.log.*
-hs_err_pid[0-9]*.log
-
-# Test sandbox files
-src/test/data/sandbox/
+# Gradle build files
+/.gradle/
+/build/
+src/main/resources/docs/
 
 # MacOS custom attributes files created by Finder
 .DS_Store
-docs/_site/
-docs/_markbind/logs/
+*.iml
+bin/
+
+/text-ui-test/ACTUAL.TXT
+text-ui-test/EXPECTED-UNIX.TXT
+
+*.class
+devenv.*
+devenv.lock
+.devenv/
+.direnv/
+
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,24 @@
-# IDEA files
-/.idea/
-/out/
-/*.iml
-
 # Gradle build files
 /.gradle/
 /build/
 src/main/resources/docs/
 
+# IDEA files
+/.idea/
+/out/
+/*.iml
+
+# Storage/log files
+/data/
+/config.json
+/preferences.json
+/*.log.*
+hs_err_pid[0-9]*.log
+
+# Test sandbox files
+src/test/data/sandbox/
+
 # MacOS custom attributes files created by Finder
 .DS_Store
-*.iml
-bin/
-
-/text-ui-test/ACTUAL.TXT
-text-ui-test/EXPECTED-UNIX.TXT
-
-*.class
-devenv.*
-devenv.lock
-.devenv/
-.direnv/
-
-node_modules/
+docs/_site/
+docs/_markbind/logs/

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -16,7 +16,7 @@ public abstract class DeleteCommand extends Command {
     }
 
     @Override
-    public String toString() {
+    public final String toString() {
         return new ToStringBuilder(this)
                 .add("targetIndex", targetIndex)
                 .toString();

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -4,7 +4,8 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Deletes a vendor identified using it's displayed index from the address book.
+ * Parent abstract class for delete commands.
+ * Contains the index of the target to be deleted.
  */
 public abstract class DeleteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -11,7 +11,6 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.vendor.Vendor;
-import seedu.address.model.event.Event;
 
 /**
  * Deletes a vendor identified using it's displayed index from the address book.
@@ -26,10 +25,10 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed vendor list.\n"
-            + "Parameters:"
+            + "Parameters: "
             + PREFIX_VENDOR
             + "INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_VENDOR + " 1";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_VENDOR + "1";
 
     public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
 
@@ -76,7 +75,8 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex);
+        return targetIndex.equals(otherDeleteCommand.targetIndex) &&
+                itemType.equals(otherDeleteCommand.itemType);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -19,6 +19,9 @@ public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
 
+    /**
+     * Enum to specify the type of item to delete.
+     */
     public enum ItemTypeToDelete {
         VENDOR,
     }
@@ -32,9 +35,13 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
 
+    // The index of item to be deleted
     private final Index targetIndex;
     private final ItemTypeToDelete itemType;
 
+    /**
+     * Creates a DeleteCommand to delete the specified item.
+     */
     public DeleteCommand(ItemTypeToDelete itemType, Index targetIndex) {
         this.targetIndex = targetIndex;
         this.itemType = itemType;
@@ -75,8 +82,8 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex) &&
-                itemType.equals(otherDeleteCommand.itemType);
+        return targetIndex.equals(otherDeleteCommand.targetIndex)
+                && itemType.equals(otherDeleteCommand.itemType);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,89 +1,18 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
-
-import java.util.List;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.logic.Messages;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
-import seedu.address.model.vendor.Vendor;
 
 /**
  * Deletes a vendor identified using it's displayed index from the address book.
  */
-public class DeleteCommand extends Command {
+public abstract class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
+    protected final Index targetIndex;
 
-    /**
-     * Enum to specify the type of item to delete.
-     */
-    public enum ItemTypeToDelete {
-        VENDOR,
-    }
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed vendor list.\n"
-            + "Parameters: "
-            + PREFIX_VENDOR
-            + "INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_VENDOR + "1";
-
-    public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
-
-    // The index of item to be deleted
-    private final Index targetIndex;
-    private final ItemTypeToDelete itemType;
-
-    /**
-     * Creates a DeleteCommand to delete the specified item.
-     */
-    public DeleteCommand(ItemTypeToDelete itemType, Index targetIndex) {
+    public DeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
-        this.itemType = itemType;
-    }
-
-    @Override
-    public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
-
-        if (itemType == ItemTypeToDelete.VENDOR) {
-            return deleteVendor(model);
-        } else {
-            throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_FORMAT);
-        }
-    }
-
-    private CommandResult deleteVendor(Model model) throws CommandException {
-        List<Vendor> lastShownList = model.getFilteredVendorList();
-
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
-        }
-
-        Vendor vendorToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deleteVendor(vendorToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_SUCCESS, Messages.format(vendorToDelete)));
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof DeleteCommand)) {
-            return false;
-        }
-
-        DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex)
-                && itemType.equals(otherDeleteCommand.itemType);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 
 import java.util.List;
 
@@ -10,6 +11,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.vendor.Vendor;
+import seedu.address.model.event.Event;
 
 /**
  * Deletes a vendor identified using it's displayed index from the address book.
@@ -18,22 +20,39 @@ public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
 
+    public enum ItemTypeToDelete {
+        VENDOR,
+    }
+
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the vendor identified by the index number used in the displayed vendor list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + ": Deletes the person identified by the index number used in the displayed vendor list.\n"
+            + "Parameters:"
+            + PREFIX_VENDOR
+            + "INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_VENDOR + " 1";
 
     public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
 
     private final Index targetIndex;
+    private final ItemTypeToDelete itemType;
 
-    public DeleteCommand(Index targetIndex) {
+    public DeleteCommand(ItemTypeToDelete itemType, Index targetIndex) {
         this.targetIndex = targetIndex;
+        this.itemType = itemType;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (itemType == ItemTypeToDelete.VENDOR) {
+            return deleteVendor(model);
+        } else {
+            throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_FORMAT);
+        }
+    }
+
+    private CommandResult deleteVendor(Model model) throws CommandException {
         List<Vendor> lastShownList = model.getFilteredVendorList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/logic/commands/DeleteVendorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteVendorCommand.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.vendor.Vendor;
+
+/**
+ * Deletes a vendor identified using it's displayed index from the address book.
+ */
+public class DeleteVendorCommand extends DeleteCommand {
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the person identified by the index number used in the displayed vendor list.\n"
+            + "Parameters: "
+            + PREFIX_VENDOR
+            + "INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_VENDOR + "1";
+
+    public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
+
+    /**
+     * Creates a DeleteVendorCommand to delete the vendor at the specified
+     * {@code Index}.
+     *
+     * @param targetIndex Index of the vendor in the filtered vendor list to delete.
+     */
+    public DeleteVendorCommand(Index targetIndex) {
+        super(targetIndex);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<Vendor> lastShownList = model.getFilteredVendorList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
+        }
+
+        Vendor vendorToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteVendor(vendorToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_SUCCESS, Messages.format(vendorToDelete)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteCommand)) {
+            return false;
+        }
+
+        DeleteVendorCommand otherDeleteCommand = (DeleteVendorCommand) other;
+        return targetIndex.equals(otherDeleteCommand.targetIndex);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,5 +12,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DATE = new Prefix("on/");
-
+    public static final Prefix PREFIX_VENDOR = new Prefix("v/");
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -7,7 +7,7 @@ import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
+import seedu.address.logic.commands.DeleteVendorCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -27,7 +27,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
 
         if (!arePrefixesPresent(argMultimap, PREFIX_VENDOR)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteVendorCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_VENDOR);
@@ -35,11 +35,10 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         try {
             Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_VENDOR).get());
             // default to vendor since event deletion is not supported
-            ItemTypeToDelete itemType = ItemTypeToDelete.VENDOR;
-            return new DeleteCommand(itemType, index);
+            return new DeleteVendorCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteVendorCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,9 +1,12 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 
+import java.util.stream.Stream;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -12,18 +15,39 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class DeleteCommandParser implements Parser<DeleteCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * Parses the given {@code String} of arguments in the context of the
+     * DeleteCommand
      * and returns a DeleteCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_VENDOR);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_VENDOR)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_VENDOR);
+
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_VENDOR).get());
+            // default to vendor since event deletion is not supported
+            ItemTypeToDelete ItemType = ItemTypeToDelete.VENDOR;
+            return new DeleteCommand(ItemType, index);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values
+     * in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 
 import java.util.stream.Stream;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
@@ -34,8 +35,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         try {
             Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_VENDOR).get());
             // default to vendor since event deletion is not supported
-            ItemTypeToDelete ItemType = ItemTypeToDelete.VENDOR;
-            return new DeleteCommand(ItemType, index);
+            ItemTypeToDelete itemType = ItemTypeToDelete.VENDOR;
+            return new DeleteCommand(itemType, index);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -91,7 +91,7 @@ public class LogicManagerTest {
      * - the feedback message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in
      * {@code expectedModel} <br>
-     * 
+     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandSuccess(String inputCommand, String expectedMessage, Model expectedModel)
@@ -104,7 +104,7 @@ public class LogicManagerTest {
     /**
      * Executes the command, confirms that a ParseException is thrown and that the
      * result message is correct.
-     * 
+     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertParseException(String inputCommand, String expectedMessage) {
@@ -114,7 +114,7 @@ public class LogicManagerTest {
     /**
      * Executes the command, confirms that a CommandException is thrown and that the
      * result message is correct.
-     * 
+     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandException(String inputCommand, String expectedMessage) {
@@ -124,7 +124,7 @@ public class LogicManagerTest {
     /**
      * Executes the command, confirms that the exception is thrown and that the
      * result message is correct.
-     * 
+     *
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
@@ -139,7 +139,7 @@ public class LogicManagerTest {
      * - the resulting error message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in
      * {@code expectedModel} <br>
-     * 
+     *
      * @see #assertCommandSuccess(String, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
@@ -151,7 +151,7 @@ public class LogicManagerTest {
     /**
      * Tests the Logic component's handling of an {@code IOException} thrown by the
      * Storage component.
-     * 
+     *
      * @param e               the exception to be thrown by the Storage component
      * @param expectedMessage the message expected inside exception thrown by the
      *                        Logic component

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -59,7 +59,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
+        String deleteCommand = "delete v/9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
     }
 
@@ -91,6 +91,7 @@ public class LogicManagerTest {
      * - the feedback message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in
      * {@code expectedModel} <br>
+     * 
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandSuccess(String inputCommand, String expectedMessage, Model expectedModel)
@@ -103,6 +104,7 @@ public class LogicManagerTest {
     /**
      * Executes the command, confirms that a ParseException is thrown and that the
      * result message is correct.
+     * 
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertParseException(String inputCommand, String expectedMessage) {
@@ -112,6 +114,7 @@ public class LogicManagerTest {
     /**
      * Executes the command, confirms that a CommandException is thrown and that the
      * result message is correct.
+     * 
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandException(String inputCommand, String expectedMessage) {
@@ -121,6 +124,7 @@ public class LogicManagerTest {
     /**
      * Executes the command, confirms that the exception is thrown and that the
      * result message is correct.
+     * 
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
@@ -135,6 +139,7 @@ public class LogicManagerTest {
      * - the resulting error message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in
      * {@code expectedModel} <br>
+     * 
      * @see #assertCommandSuccess(String, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
@@ -146,6 +151,7 @@ public class LogicManagerTest {
     /**
      * Tests the Logic component's handling of an {@code IOException} thrown by the
      * Storage component.
+     * 
      * @param e               the exception to be thrown by the Storage component
      * @param expectedMessage the message expected inside exception thrown by the
      *                        Logic component

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -30,7 +31,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Vendor vendorToDelete = model.getFilteredVendorList().get(INDEX_FIRST_VENDOR.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_VENDOR);
+        DeleteCommand deleteCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_VENDOR_SUCCESS,
                 Messages.format(vendorToDelete));
@@ -44,7 +45,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredVendorList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
     }
@@ -54,7 +55,7 @@ public class DeleteCommandTest {
         showVendorAtIndex(model, INDEX_FIRST_VENDOR);
 
         Vendor vendorToDelete = model.getFilteredVendorList().get(INDEX_FIRST_VENDOR.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_VENDOR);
+        DeleteCommand deleteCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_VENDOR_SUCCESS,
                 Messages.format(vendorToDelete));
@@ -74,21 +75,21 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getVendorList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_VENDOR);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_VENDOR);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_SECOND_VENDOR);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_VENDOR);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -104,7 +105,7 @@ public class DeleteCommandTest {
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, targetIndex);
         String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
         assertEquals(expected, deleteCommand.toString());
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,7 +8,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for
+ * Contains unit tests for
  * {@code DeleteCommand}.
  */
 public class DeleteCommandTest {

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showVendorAtIndex;
+import static seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_VENDOR;
 import static seedu.address.testutil.TypicalVendors.getTypicalAddressBook;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -84,6 +84,7 @@ public class DeleteCommandTest {
     public void equals() {
         DeleteCommand deleteFirstCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR);
         DeleteCommand deleteSecondCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_SECOND_VENDOR);
+        DeleteCommand deleteThirdCommand = new DeleteCommand(null, INDEX_FIRST_VENDOR);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
@@ -100,6 +101,9 @@ public class DeleteCommandTest {
 
         // different vendor -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+
+        // different item deletion type -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteThirdCommand));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -1,24 +1,11 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showVendorAtIndex;
-import static seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_VENDOR;
-import static seedu.address.testutil.TypicalVendors.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
-import seedu.address.model.vendor.Vendor;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -26,100 +13,23 @@ import seedu.address.model.vendor.Vendor;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private class DeleteCommandStub extends DeleteCommand {
+        public DeleteCommandStub(Index targetIndex) {
+            super(targetIndex);
+        }
 
-    @Test
-    public void execute_validIndexUnfilteredList_success() {
-        Vendor vendorToDelete = model.getFilteredVendorList().get(INDEX_FIRST_VENDOR.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR);
-
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_VENDOR_SUCCESS,
-                Messages.format(vendorToDelete));
-
-        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.deleteVendor(vendorToDelete);
-
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredVendorList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, outOfBoundIndex);
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void execute_validIndexFilteredList_success() {
-        showVendorAtIndex(model, INDEX_FIRST_VENDOR);
-
-        Vendor vendorToDelete = model.getFilteredVendorList().get(INDEX_FIRST_VENDOR.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR);
-
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_VENDOR_SUCCESS,
-                Messages.format(vendorToDelete));
-
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.deleteVendor(vendorToDelete);
-        showNoVendor(expectedModel);
-
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showVendorAtIndex(model, INDEX_FIRST_VENDOR);
-
-        Index outOfBoundIndex = INDEX_SECOND_VENDOR;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getVendorList().size());
-
-        DeleteCommand deleteCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, outOfBoundIndex);
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_SECOND_VENDOR);
-        DeleteCommand deleteThirdCommand = new DeleteCommand(null, INDEX_FIRST_VENDOR);
-
-        // same object -> returns true
-        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
-
-        // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR);
-        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
-
-        // different types -> returns false
-        assertFalse(deleteFirstCommand.equals(1));
-
-        // null -> returns false
-        assertFalse(deleteFirstCommand.equals(null));
-
-        // different vendor -> returns false
-        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
-
-        // different item deletion type -> returns false
-        assertFalse(deleteFirstCommand.equals(deleteThirdCommand));
+        @Override
+        public CommandResult execute(Model model) {
+            // This method is not used in the test
+            return null;
+        }
     }
 
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(ItemTypeToDelete.VENDOR, targetIndex);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        DeleteCommandStub deleteCommand = new DeleteCommandStub(targetIndex);
+        String expected = DeleteCommandStub.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
         assertEquals(expected, deleteCommand.toString());
-    }
-
-    /**
-     * Updates {@code model}'s filtered list to show no one.
-     */
-    private void showNoVendor(Model model) {
-        model.updateFilteredVendorList(p -> false);
-
-        assertTrue(model.getFilteredVendorList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -13,6 +13,14 @@ import seedu.address.model.Model;
  */
 public class DeleteCommandTest {
 
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        DeleteCommandStub deleteCommand = new DeleteCommandStub(targetIndex);
+        String expected = DeleteCommandStub.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, deleteCommand.toString());
+    }
+
     private class DeleteCommandStub extends DeleteCommand {
         public DeleteCommandStub(Index targetIndex) {
             super(targetIndex);
@@ -23,13 +31,5 @@ public class DeleteCommandTest {
             // This method is not used in the test
             return null;
         }
-    }
-
-    @Test
-    public void toStringMethod() {
-        Index targetIndex = Index.fromOneBased(1);
-        DeleteCommandStub deleteCommand = new DeleteCommandStub(targetIndex);
-        String expected = DeleteCommandStub.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
-        assertEquals(expected, deleteCommand.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteVendorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteVendorCommandTest.java
@@ -1,0 +1,111 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showVendorAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_VENDOR;
+import static seedu.address.testutil.TypicalVendors.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.vendor.Vendor;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteVendorCommand}.
+ */
+public class DeleteVendorCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Vendor vendorToDelete = model.getFilteredVendorList().get(INDEX_FIRST_VENDOR.getZeroBased());
+        DeleteVendorCommand deleteCommand = new DeleteVendorCommand(INDEX_FIRST_VENDOR);
+
+        String expectedMessage = String.format(DeleteVendorCommand.MESSAGE_DELETE_VENDOR_SUCCESS,
+                Messages.format(vendorToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteVendor(vendorToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredVendorList().size() + 1);
+        DeleteVendorCommand deleteCommand = new DeleteVendorCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showVendorAtIndex(model, INDEX_FIRST_VENDOR);
+
+        Vendor vendorToDelete = model.getFilteredVendorList().get(INDEX_FIRST_VENDOR.getZeroBased());
+        DeleteVendorCommand deleteCommand = new DeleteVendorCommand(INDEX_FIRST_VENDOR);
+
+        String expectedMessage = String.format(DeleteVendorCommand.MESSAGE_DELETE_VENDOR_SUCCESS,
+                Messages.format(vendorToDelete));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteVendor(vendorToDelete);
+        showNoVendor(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showVendorAtIndex(model, INDEX_FIRST_VENDOR);
+
+        Index outOfBoundIndex = INDEX_SECOND_VENDOR;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getVendorList().size());
+
+        DeleteVendorCommand deleteCommand = new DeleteVendorCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteVendorCommand deleteFirstCommand = new DeleteVendorCommand(INDEX_FIRST_VENDOR);
+        DeleteVendorCommand deleteSecondCommand = new DeleteVendorCommand(INDEX_SECOND_VENDOR);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteVendorCommand deleteFirstCommandCopy = new DeleteVendorCommand(INDEX_FIRST_VENDOR);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different vendor -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoVendor(Model model) {
+        model.updateFilteredVendorList(p -> false);
+
+        assertTrue(model.getFilteredVendorList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
@@ -24,7 +25,6 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.Date;
 import seedu.address.model.event.Event;
@@ -104,8 +104,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
-                () -> parser.parseCommand(""));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
+            -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
 
@@ -23,6 +24,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.Date;
 import seedu.address.model.event.Event;
@@ -61,8 +63,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser
-                .parseCommand(DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_VENDOR.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_VENDOR), command);
+                .parseCommand(DeleteCommand.COMMAND_WORD + " " + PREFIX_VENDOR + INDEX_FIRST_VENDOR.getOneBased());
+        assertEquals(new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR), command);
     }
 
     @Test
@@ -102,8 +104,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-             -> parser.parseCommand(""));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
+                () -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
@@ -18,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.CreateEventCommand;
 import seedu.address.logic.commands.CreateVendorCommand;
-import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteVendorCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditVendorDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -61,10 +60,11 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_delete() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser
-                .parseCommand(DeleteCommand.COMMAND_WORD + " " + PREFIX_VENDOR + INDEX_FIRST_VENDOR.getOneBased());
-        assertEquals(new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR), command);
+    public void parseCommand_deleteVendor() throws Exception {
+        DeleteVendorCommand command = (DeleteVendorCommand) parser
+                .parseCommand(
+                        DeleteVendorCommand.COMMAND_WORD + " " + PREFIX_VENDOR + INDEX_FIRST_VENDOR.getOneBased());
+        assertEquals(new DeleteVendorCommand(INDEX_FIRST_VENDOR), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
@@ -8,7 +9,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,14 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteVendorCommand;
 
 public class DeleteCommandParserTest {
 
@@ -16,16 +15,17 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, " v/1", new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR));
+        assertParseSuccess(parser, " v/1", new DeleteVendorCommand(INDEX_FIRST_VENDOR));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
         // invalid index
         assertParseFailure(parser, "v/1abc",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteVendorCommand.MESSAGE_USAGE));
 
         // no prefix
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteVendorCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -10,14 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
 
-/**
- * As we are only doing white-box testing, our test cases do not cover path
- * variations outside of the DeleteCommand code. For example, inputs "v/1" and
- * "v/1abc" take the same path through the DeleteCommand, and therefore we test
- * only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
- */
 public class DeleteCommandParserTest {
 
     private DeleteCommandParser parser = new DeleteCommandParser();
@@ -29,6 +21,11 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
+        // invalid index
+        assertParseFailure(parser, "v/1abc",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        // no prefix
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -8,11 +8,13 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteCommand.ItemTypeToDelete;
 
 /**
- * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the DeleteCommand, and therefore we test only one of them.
+ * As we are only doing white-box testing, our test cases do not cover path
+ * variations outside of the DeleteCommand code. For example, inputs "v/1" and
+ * "v/1abc" take the same path through the DeleteCommand, and therefore we test
+ * only one of them.
  * The path variation for those two cases occur inside the ParserUtil, and
  * therefore should be covered by the ParserUtilTest.
  */
@@ -22,7 +24,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_VENDOR));
+        assertParseSuccess(parser, " v/1", new DeleteCommand(ItemTypeToDelete.VENDOR, INDEX_FIRST_VENDOR));
     }
 
     @Test


### PR DESCRIPTION
The command format is updated as per mentioned in #77
`delete v/1`

- Deleting multiple items was not implemented due to the complexity of testing
- The command is extended in such a way adding delete for events should be trivial 
