### PR TITLE
Refactor CreateEventCommand and CreateVendorCommand to stem from the same Parent Class

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CreateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateCommand.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
+
+/**
+ * Parent abstract class for create commands.
+ * Contains the index of the target to be deleted.
+ */
+public abstract class CreateCommand extends Command {
+
+    public static final String COMMAND_WORD = "create";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Creates a vendor or event and adds it to the list.\n"
+            + "Parameters: " + PREFIX_VENDOR + "<empty> or " + PREFIX_EVENT + "<empty>" + "\n"
+            + "Example to create a vendor: " + COMMAND_WORD + " " + PREFIX_VENDOR + " <other vendor parameters>\n"
+            + "Example to create an event: " + COMMAND_WORD + " " + PREFIX_EVENT + " <other event parameters>";
+}

--- a/src/main/java/seedu/address/logic/commands/CreateEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateEventCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -12,11 +13,10 @@ import seedu.address.model.event.Event;
 /**
  * Creates an event in the address book.
  */
-public class CreateEventCommand extends Command {
-    public static final String COMMAND_WORD = "create_event";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a new event in the address book. "
+public class CreateEventCommand extends CreateCommand {
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a new event in the address book.\n"
             + "Parameters: "
+            + PREFIX_EVENT + "<empty> "
             + PREFIX_NAME + "NAME "
             + PREFIX_DATE + "DATE";
 

--- a/src/main/java/seedu/address/logic/commands/CreateVendorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateVendorCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -15,14 +16,21 @@ import seedu.address.model.vendor.Vendor;
 /**
  * Adds a vendor to the address book.
  */
-public class CreateVendorCommand extends Command {
+public class CreateVendorCommand extends CreateCommand {
 
-    public static final String COMMAND_WORD = "create_vendor";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a vendor to the address book. " + "Parameters: "
-            + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_DESCRIPTION + "DESCRIPTION " + "[" + PREFIX_TAG
-            + "TAG]...\n" + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Adam's Bakery " + PREFIX_PHONE
-            + "98765432 " + PREFIX_DESCRIPTION + "Pastries and cakes, bake in a day " + PREFIX_TAG + "pastry "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a vendor to the address book.\n"
+            + "Parameters: "
+            + PREFIX_VENDOR + "<empty> "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_PHONE + "PHONE "
+            + PREFIX_DESCRIPTION + "DESCRIPTION "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: "
+            + COMMAND_WORD + " "
+            + PREFIX_NAME + "Adam's Bakery "
+            + PREFIX_PHONE + "98765432 "
+            + PREFIX_DESCRIPTION + "Pastries and cakes, bake in a day "
+            + PREFIX_TAG + "pastry "
             + PREFIX_TAG + "fast";
 
     public static final String MESSAGE_SUCCESS = "New vendor added: %1$s";

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CreateCommand;
 import seedu.address.logic.commands.CreateEventCommand;
 import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.commands.DeleteCommand;
@@ -54,9 +55,6 @@ public class AddressBookParser {
 
         switch (commandWord) {
 
-        case CreateVendorCommand.COMMAND_WORD:
-            return new CreateVendorCommandParser().parse(arguments);
-
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
 
@@ -78,8 +76,8 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
-        case CreateEventCommand.COMMAND_WORD:
-            return new CreateEventCommandParser().parse(arguments);
+        case CreateCommand.COMMAND_WORD:
+            return new CreateCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,8 +11,6 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CreateCommand;
-import seedu.address.logic.commands.CreateEventCommand;
-import seedu.address.logic.commands.CreateVendorCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;

--- a/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
@@ -4,8 +4,6 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 
-import java.util.stream.Stream;
-
 import seedu.address.logic.commands.CreateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
@@ -38,13 +38,4 @@ public class CreateCommandParser implements Parser<CreateCommand> {
         }
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values
-     * in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.CreateCommand;
+import seedu.address.logic.commands.CreateEventCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.event.Date;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.Name;
+
+public class CreateCommandParser implements Parser<CreateCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the CreateCommand
+     * and returns an CreateCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public CreateCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_VENDOR, PREFIX_EVENT);
+
+        if (!(argMultimap.exactlyOnePrefixPresent(PREFIX_VENDOR, PREFIX_EVENT))
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_VENDOR, PREFIX_EVENT);
+
+        final boolean isEventCreate = argMultimap.getValue(PREFIX_EVENT).isPresent();
+
+        if (isEventCreate) {
+            return new CreateEventCommandParser().parse(args);
+        } else {
+            return new CreateVendorCommandParser().parse(args);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values
+     * in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
@@ -1,20 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.CreateCommand;
-import seedu.address.logic.commands.CreateEventCommand;
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.event.Date;
-import seedu.address.model.event.Event;
-import seedu.address.model.event.Name;
 
 public class CreateCommandParser implements Parser<CreateCommand> {
     /**

--- a/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
@@ -9,6 +9,9 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.CreateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+/**
+ * Parses input arguments and creates a new CreateCommand object
+ */
 public class CreateCommandParser implements Parser<CreateCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the CreateCommand

--- a/src/main/java/seedu/address/logic/parser/CreateEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateEventCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.stream.Stream;
@@ -20,17 +21,18 @@ public class CreateEventCommandParser implements Parser<CreateEventCommand> {
      * Parses the given {@code String} of arguments in the context of the CreateEventCommand
      * and returns an CreateEventCommand object for execution.
      *
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform to the expected format
      */
     public CreateEventCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DATE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_EVENT, PREFIX_NAME, PREFIX_DATE);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_DATE)
+        if (!arePrefixesPresent(argMultimap, PREFIX_EVENT, PREFIX_NAME, PREFIX_DATE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateEventCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_DATE);
+
         Name name = ParserUtil.parseEventName(argMultimap.getValue(PREFIX_NAME).get());
         Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
 
@@ -47,4 +49,5 @@ public class CreateEventCommandParser implements Parser<CreateEventCommand> {
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
+
 }

--- a/src/main/java/seedu/address/logic/parser/CreateVendorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateVendorCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -18,25 +19,27 @@ import seedu.address.model.vendor.Phone;
 import seedu.address.model.vendor.Vendor;
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new CreateVendorCommand object
  */
 public class CreateVendorCommandParser implements Parser<CreateVendorCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddCommand
-     * and returns an AddCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * Parses the given {@code String} of arguments in the context of the CreateVendorCommand
+     * and returns an CreateVendorCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform to the expected format
      */
     public CreateVendorCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_DESCRIPTION,
-                PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_VENDOR, PREFIX_NAME, PREFIX_PHONE,
+                PREFIX_DESCRIPTION, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_PHONE)
+        if (!arePrefixesPresent(argMultimap, PREFIX_VENDOR, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_PHONE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateVendorCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_DESCRIPTION);
+
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -4,8 +4,6 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 
-import java.util.stream.Stream;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteEventCommand;

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -77,13 +77,4 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values
-     * in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -85,4 +85,5 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
+
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalVendors.AMY;
 
@@ -175,7 +176,8 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing an add command
-        String addCommand = CreateVendorCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY;
+        String addCommand = CreateVendorCommand.COMMAND_WORD + " " + PREFIX_VENDOR +
+                NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY;
         Vendor expectedVendor = new VendorBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addVendor(expectedVendor);

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -176,8 +176,8 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing an add command
-        String addCommand = CreateVendorCommand.COMMAND_WORD + " " + PREFIX_VENDOR +
-                NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY;
+        String addCommand = CreateVendorCommand.COMMAND_WORD + " " + PREFIX_VENDOR
+                + NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY;
         Vendor expectedVendor = new VendorBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addVendor(expectedVendor);

--- a/src/test/java/seedu/address/logic/commands/CreateVendorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateVendorCommandTest.java
@@ -26,7 +26,7 @@ import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 import seedu.address.testutil.VendorBuilder;
 
-public class AddCommandTest {
+public class CreateVendorCommandTest {
 
     @Test
     public void constructor_nullVendor_throwsNullPointerException() {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -34,6 +34,7 @@ import seedu.address.model.event.Name;
 import seedu.address.model.vendor.NameContainsKeywordsPredicate;
 import seedu.address.model.vendor.Vendor;
 import seedu.address.testutil.EditVendorDescriptorBuilder;
+import seedu.address.testutil.EventUtil;
 import seedu.address.testutil.VendorBuilder;
 import seedu.address.testutil.VendorUtil;
 
@@ -44,7 +45,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_add() throws Exception {
         Vendor vendor = new VendorBuilder().build();
-        CreateVendorCommand command = (CreateVendorCommand) parser.parseCommand(VendorUtil.getAddCommand(vendor));
+        CreateVendorCommand command = (CreateVendorCommand) parser.parseCommand(VendorUtil.getCreateVendorCommand(vendor));
         assertEquals(new CreateVendorCommand(vendor), command);
     }
 
@@ -52,7 +53,7 @@ public class AddressBookParserTest {
     public void parseCommand_createEvent() throws Exception {
         Event partyEvent = new Event(new Name("Party"), new Date("2024-10-10"));
         CreateEventCommand command = (CreateEventCommand) parser
-                .parseCommand("create_event n/Party on/2024-10-10");
+                .parseCommand(EventUtil.getCreateEventCommand(partyEvent));
         assertEquals(new CreateEventCommand(partyEvent), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -45,7 +45,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_add() throws Exception {
         Vendor vendor = new VendorBuilder().build();
-        CreateVendorCommand command = (CreateVendorCommand) parser.parseCommand(VendorUtil.getCreateVendorCommand(vendor));
+        CreateVendorCommand command = (CreateVendorCommand) parser
+                .parseCommand(VendorUtil.getCreateVendorCommand(vendor));
         assertEquals(new CreateVendorCommand(vendor), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java
@@ -1,2 +1,93 @@
-package seedu.address.logic.parser;public class CreateCommandParserTest {
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
+import static seedu.address.testutil.TypicalVendors.BOB;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.CreateCommand;
+import seedu.address.logic.commands.CreateEventCommand;
+import seedu.address.logic.commands.CreateVendorCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteEventCommand;
+import seedu.address.logic.commands.DeleteVendorCommand;
+import seedu.address.model.event.Date;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.Name;
+import seedu.address.model.vendor.Vendor;
+import seedu.address.testutil.VendorBuilder;
+
+public class CreateCommandParserTest {
+    private CreateCommandParser parser = new CreateCommandParser();
+
+    @Test
+    public void parse_NoPrefixSpecified_throwsParseException() {
+        assertParseFailure(parser, " ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_eventAndVendorPrefixesSpecified_throwsParseException() {
+        assertParseFailure(parser, " v/ e/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_eventPrefixSpecifiedWithNoEventParameters_throwsParseException() {
+        assertParseFailure(parser, " e/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateEventCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_eventPrefixSpecifiedWithValidEventParameters_success() {
+        assertParseSuccess(parser, " " + PREFIX_EVENT + " " + PREFIX_NAME + "Birthday Party" + " "
+                        + PREFIX_DATE + "2024-10-10",
+                new CreateEventCommand(new Event(new Name("Birthday Party"), new Date("2024-10-10"))));
+    }
+
+    @Test
+    public void parse_eventPrefixContainsParameterValueWithValidEventParameters_success() {
+        assertParseSuccess(parser, " " + PREFIX_EVENT + "Some event parameter" + " " + PREFIX_NAME
+                        + "Birthday Party" + " " + PREFIX_DATE + "2024-10-10",
+                new CreateEventCommand(new Event(new Name("Birthday Party"), new Date("2024-10-10"))));
+    }
+
+    @Test
+    public void parse_vendorPrefixSpecifiedWithNoVendorParameters_throwsParseException() {
+        assertParseFailure(parser, " v/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateVendorCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_vendorPrefixSpecifiedWithValidVendorParameters_success() {
+        Vendor expectedVendor = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + " " + PREFIX_VENDOR + NAME_DESC_BOB + PHONE_DESC_BOB
+                        + DESCRIPTION_DESC_BOB + TAG_DESC_FRIEND,
+                new CreateVendorCommand(expectedVendor));
+    }
+
+    @Test
+    public void parse_vendorPrefixContainsParameterValueWithValidVendorParameters_success() {
+        Vendor expectedVendor = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + " " + PREFIX_VENDOR + "Some event parameter"
+                        + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_FRIEND,
+                new CreateVendorCommand(expectedVendor));
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.parser;public class CreateCommandParserTest {
+}

--- a/src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java
@@ -2,12 +2,10 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
@@ -15,16 +13,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
 import static seedu.address.testutil.TypicalVendors.BOB;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.CreateCommand;
 import seedu.address.logic.commands.CreateEventCommand;
 import seedu.address.logic.commands.CreateVendorCommand;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.DeleteEventCommand;
-import seedu.address.logic.commands.DeleteVendorCommand;
 import seedu.address.model.event.Date;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.Name;
@@ -35,7 +30,7 @@ public class CreateCommandParserTest {
     private CreateCommandParser parser = new CreateCommandParser();
 
     @Test
-    public void parse_NoPrefixSpecified_throwsParseException() {
+    public void parse_noPrefixSpecified_throwsParseException() {
         assertParseFailure(parser, " ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateCommand.MESSAGE_USAGE));
     }

--- a/src/test/java/seedu/address/logic/parser/CreateEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateEventCommandParserTest.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -27,7 +28,8 @@ public class CreateEventCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + " " + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE + "2024-10-10",
+                PREAMBLE_WHITESPACE + " " + PREFIX_EVENT + " "
+                        + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE + "2024-10-10",
                 new CreateEventCommand(expectedEvent));
     }
 
@@ -35,36 +37,61 @@ public class CreateEventCommandParserTest {
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateEventCommand.MESSAGE_USAGE);
 
+        // missing event prefix
+        assertParseFailure(parser, " " + PREFIX_EVENT + " Zoo Excursion" + " " + PREFIX_DATE + "2024-10-10",
+                expectedMessage);
+
         // missing name prefix
-        assertParseFailure(parser, "Zoo Excursion" + " " + PREFIX_DATE + "2024-10-10",
+        assertParseFailure(parser, " " + PREFIX_EVENT + " Zoo Excursion" + " " + PREFIX_DATE + "2024-10-10",
                 expectedMessage);
 
         // missing date prefix
-        assertParseFailure(parser, PREFIX_NAME + "Zoo Excursion" + " " + "2024-10-10",
+        assertParseFailure(parser, " " + PREFIX_EVENT
+                        + " " + PREFIX_NAME + "Zoo Excursion" + " " + "2024-10-10",
                 expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, "Zoo Excursion" + " " + "2024-10-10",
+        assertParseFailure(parser, " " + PREFIX_EVENT + "Zoo Excursion" + " " + "2024-10-10",
                 expectedMessage);
+    }
+
+    @Test
+    public void parse_ignoresEventPrefixValue_success() {
+
+        Event expectedEvent = excursionEvent;
+
+        // event prefix contains parameter value
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + " " + PREFIX_EVENT + "some parameter" + " "
+                        + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE + "2024-10-10",
+                new CreateEventCommand(expectedEvent));
+
+        // event prefix contains no parameter value
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + " " + PREFIX_EVENT + " " + PREFIX_NAME
+                        + "Zoo Excursion" + " " + PREFIX_DATE + "2024-10-10",
+                new CreateEventCommand(expectedEvent));
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, " " + PREFIX_NAME + "Zoo Excursion?" + " " + PREFIX_DATE + "2024-10-10",
+        assertParseFailure(parser, " " + PREFIX_EVENT + " " + PREFIX_NAME + "Zoo Excursion?" + " "
+                        + PREFIX_DATE + "2024-10-10",
                 Name.MESSAGE_CONSTRAINTS);
 
         // invalid date
-        assertParseFailure(parser, " " + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE + "10 October 2024",
+        assertParseFailure(parser, " " + PREFIX_EVENT + " " + PREFIX_NAME + "Zoo Excursion" + " "
+                        + PREFIX_DATE + "10 October 2024",
                 Date.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, " " + PREFIX_NAME + "Zoo Excursion?" + " " + PREFIX_DATE
-                + "10 October 2024", Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " " + PREFIX_EVENT + " " + PREFIX_NAME + "Zoo Excursion?" + " "
+                        + PREFIX_DATE + "10 October 2024",
+                Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser,
-                PREAMBLE_NON_EMPTY + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE + "10 October 2024",
+                PREAMBLE_NON_EMPTY + " " + PREFIX_EVENT + PREFIX_NAME + "Zoo Excursion" + " " + PREFIX_DATE
+                        + "10 October 2024",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateEventCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/CreateVendorCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateVendorCommandParserTest.java
@@ -39,7 +39,7 @@ import seedu.address.model.vendor.Phone;
 import seedu.address.model.vendor.Vendor;
 import seedu.address.testutil.VendorBuilder;
 
-public class AddCommandParserTest {
+public class CreateVendorCommandParserTest {
     private CreateVendorCommandParser parser = new CreateVendorCommandParser();
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/CreateVendorCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateVendorCommandParserTest.java
@@ -168,7 +168,7 @@ public class CreateVendorCommandParserTest {
 
         // invalid tag
         assertParseFailure(parser,
-                " " + PREFIX_VENDOR + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB+ INVALID_TAG_DESC
+                " " + PREFIX_VENDOR + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + INVALID_TAG_DESC
                         + VALID_TAG_FRIEND,
                 Tag.MESSAGE_CONSTRAINTS);
 

--- a/src/test/java/seedu/address/logic/parser/CreateVendorCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateVendorCommandParserTest.java
@@ -23,6 +23,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalVendors.AMY;
@@ -48,20 +49,23 @@ public class CreateVendorCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_FRIEND,
+                PREAMBLE_WHITESPACE + " " + PREFIX_VENDOR + NAME_DESC_BOB + PHONE_DESC_BOB
+                        + DESCRIPTION_DESC_BOB + TAG_DESC_FRIEND,
                 new CreateVendorCommand(expectedVendor));
 
         // multiple tags - all accepted
         Vendor expectedVendorMultipleTags = new VendorBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
         assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                " " + PREFIX_VENDOR + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB
+                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 new CreateVendorCommand(expectedVendorMultipleTags));
     }
 
     @Test
     public void parse_repeatedNonTagValue_failure() {
-        String validExpectedVendorString = NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_FRIEND;
+        String validExpectedVendorString = " " + PREFIX_VENDOR
+                + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_FRIEND;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedVendorString,
@@ -71,7 +75,7 @@ public class CreateVendorCommandParserTest {
         assertParseFailure(parser, PHONE_DESC_AMY + validExpectedVendorString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-        // multiple descriptiones
+        // multiple descriptions
         assertParseFailure(parser, DESCRIPTION_DESC_AMY + validExpectedVendorString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
 
@@ -114,7 +118,7 @@ public class CreateVendorCommandParserTest {
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Vendor expectedVendor = new VendorBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY,
+        assertParseSuccess(parser, " " + PREFIX_VENDOR + NAME_DESC_AMY + PHONE_DESC_AMY + DESCRIPTION_DESC_AMY,
                 new CreateVendorCommand(expectedVendor));
     }
 
@@ -122,49 +126,61 @@ public class CreateVendorCommandParserTest {
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateVendorCommand.MESSAGE_USAGE);
 
+        // missing vendor prefix
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
+
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
+        assertParseFailure(parser, " " + PREFIX_VENDOR
+                + VALID_NAME_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
 
         // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
+        assertParseFailure(parser, " " + PREFIX_VENDOR
+                + NAME_DESC_BOB + VALID_PHONE_BOB + DESCRIPTION_DESC_BOB, expectedMessage);
 
         // missing description prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_DESCRIPTION_BOB, expectedMessage);
+        assertParseFailure(parser, " " + PREFIX_VENDOR
+                + NAME_DESC_BOB + PHONE_DESC_BOB + VALID_DESCRIPTION_BOB, expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_DESCRIPTION_BOB, expectedMessage);
+        assertParseFailure(parser, " " + PREFIX_VENDOR
+                + VALID_NAME_BOB + VALID_PHONE_BOB + VALID_DESCRIPTION_BOB, expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser,
-                INVALID_NAME_DESC + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                " " + PREFIX_VENDOR + INVALID_NAME_DESC + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB
+                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser,
-                NAME_DESC_BOB + INVALID_PHONE_DESC + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                " " + PREFIX_VENDOR + NAME_DESC_BOB + INVALID_PHONE_DESC + DESCRIPTION_DESC_BOB
+                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Phone.MESSAGE_CONSTRAINTS);
 
         // invalid description
         assertParseFailure(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                " " + PREFIX_VENDOR + NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC
+                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Description.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND,
+                " " + PREFIX_VENDOR + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB+ INVALID_TAG_DESC
+                        + VALID_TAG_FRIEND,
                 Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + INVALID_DESCRIPTION_DESC,
+        assertParseFailure(parser, " " + PREFIX_VENDOR + INVALID_NAME_DESC + PHONE_DESC_BOB
+                        + INVALID_DESCRIPTION_DESC,
                 Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser,
-                PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND
-                        + TAG_DESC_FRIEND,
+                PREAMBLE_NON_EMPTY + " " + PREFIX_VENDOR + NAME_DESC_BOB + PHONE_DESC_BOB
+                        + DESCRIPTION_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateVendorCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/testutil/EventUtil.java
+++ b/src/test/java/seedu/address/testutil/EventUtil.java
@@ -1,20 +1,11 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
-
-import java.util.Set;
 
 import seedu.address.logic.commands.CreateVendorCommand;
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.model.event.Event;
-import seedu.address.model.tag.Tag;
-import seedu.address.model.vendor.Vendor;
 
 /**
  * A utility class for Event.

--- a/src/test/java/seedu/address/testutil/EventUtil.java
+++ b/src/test/java/seedu/address/testutil/EventUtil.java
@@ -1,2 +1,41 @@
-package seedu.address.testutil;public class EventUtil {
+package seedu.address.testutil;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
+
+import java.util.Set;
+
+import seedu.address.logic.commands.CreateVendorCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.model.event.Event;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.vendor.Vendor;
+
+/**
+ * A utility class for Event.
+ */
+public class EventUtil {
+
+    /**
+     * Returns a create event command string for adding the {@code event}.
+     */
+    public static String getCreateEventCommand(Event event) {
+        return CreateVendorCommand.COMMAND_WORD + " " + PREFIX_EVENT + " " + getEventDetails(event);
+    }
+
+    /**
+     * Returns the part of command string for the given {@code vendor}'s details.
+     */
+    public static String getEventDetails(Event event) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(PREFIX_NAME + event.getName().fullName + " ");
+        sb.append(PREFIX_DATE + event.getDate().toString() + " ");
+        return sb.toString();
+    }
+
 }

--- a/src/test/java/seedu/address/testutil/EventUtil.java
+++ b/src/test/java/seedu/address/testutil/EventUtil.java
@@ -1,0 +1,2 @@
+package seedu.address.testutil;public class EventUtil {
+}

--- a/src/test/java/seedu/address/testutil/VendorUtil.java
+++ b/src/test/java/seedu/address/testutil/VendorUtil.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 
 import java.util.Set;
 
@@ -21,7 +22,7 @@ public class VendorUtil {
      * Returns an add command string for adding the {@code vendor}.
      */
     public static String getAddCommand(Vendor vendor) {
-        return CreateVendorCommand.COMMAND_WORD + " " + getVendorDetails(vendor);
+        return CreateVendorCommand.COMMAND_WORD + " " + PREFIX_VENDOR + " " + getVendorDetails(vendor);
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/VendorUtil.java
+++ b/src/test/java/seedu/address/testutil/VendorUtil.java
@@ -21,7 +21,7 @@ public class VendorUtil {
     /**
      * Returns an add command string for adding the {@code vendor}.
      */
-    public static String getAddCommand(Vendor vendor) {
+    public static String getCreateVendorCommand(Vendor vendor) {
         return CreateVendorCommand.COMMAND_WORD + " " + PREFIX_VENDOR + " " + getVendorDetails(vendor);
     }
 


### PR DESCRIPTION
Resolves #84 

The class hierarchy for commands to create vendors and events is similar to that of `DeleteCommand`. However, it should be noted that the parse logic to create a vendor/event is separated into two parsers.
- `CreateCommandParser` is in charge of understanding the command and passing the arguments to either `CreateVendorCommandParser` or `CreateEventCommandParser`
- Unlike `DeleteVendorCommand` and `DeleteEventCommand`, the create commands do not share any parameters. Hence, the implementation of the `CreateCommand` class is barebones.