### PR TITLE
Allow events in memory to be persistent

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
@@ -1,0 +1,63 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.event.Date;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.Name;
+
+/**
+ * Jackson-friendly version of {@link Event}.
+ */
+public class JsonAdaptedEvent {
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Event's %s field is missing!";
+
+    private final String name;
+    private final String date;
+
+    /**
+     * Constructs a {@code JsonAdaptedEvent} with the given event details.
+     */
+    @JsonCreator
+    public JsonAdaptedEvent(@JsonProperty("name") String name, @JsonProperty("date") String date) {
+        this.name = name;
+        this.date = date;
+    }
+
+    /**
+     * Converts a given {@code Event} into this class for Jackson use.
+     */
+    public JsonAdaptedEvent(Event source) {
+        name = source.getName().fullName;
+        date = source.getDate().toString();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted event object into the model's
+     * {@code Event} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in
+     *                               the adapted vendor.
+     */
+    public Event toModelType() throws IllegalValueException {
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+        }
+        final Name modelName = new Name(name);
+
+        if (date == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName()));
+        }
+        if (!Date.isValidDate(date)) {
+            throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
+        }
+        final Date modeldate = new Date(date);
+
+        return new Event(modelName, modeldate);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -2,7 +2,6 @@ package seedu.address.storage;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 
 /**
@@ -20,15 +20,19 @@ import seedu.address.model.vendor.Vendor;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_VENDOR = "Vendors list contains duplicate vendor(s).";
+    public static final String MESSAGE_DUPLICATE_EVENT = "Event list contains duplicate event(s).";
 
     private final List<JsonAdaptedVendor> vendors = new ArrayList<>();
+    private final List<JsonAdaptedEvent> events = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given vendors.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("vendors") List<JsonAdaptedVendor> vendors) {
+    public JsonSerializableAddressBook(@JsonProperty("vendors") List<JsonAdaptedVendor> vendors,
+                                       @JsonProperty("events") List<JsonAdaptedEvent> events) {
         this.vendors.addAll(vendors);
+        this.events.addAll(events);
     }
 
     /**
@@ -37,7 +41,8 @@ class JsonSerializableAddressBook {
      * @param source future changes to this will not affect the created {@code JsonSerializableAddressBook}.
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
-        vendors.addAll(source.getVendorList().stream().map(JsonAdaptedVendor::new).collect(Collectors.toList()));
+        vendors.addAll(source.getVendorList().stream().map(JsonAdaptedVendor::new).toList());
+        events.addAll(source.getEventList().stream().map(JsonAdaptedEvent::new).toList());
     }
 
     /**
@@ -53,6 +58,14 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_VENDOR);
             }
             addressBook.addVendor(vendor);
+        }
+
+        for (JsonAdaptedEvent jsonAdaptedEvent : events) {
+            Event event = jsonAdaptedEvent.toModelType();
+            if (addressBook.hasEvent(event)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_EVENT);
+            }
+            addressBook.addEvent(event);
         }
         return addressBook;
     }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateEventAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateEventAddressBook.json
@@ -1,0 +1,10 @@
+{
+  "vendors" : [ ],
+  "events": [ {
+    "name": "Carl Kurz Tea Party",
+    "date": "2021-12-12"
+  }, {
+    "name": "Carl Kurz Tea Party",
+    "date": "2021-12-12"
+  } ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateVendorAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateVendorAddressBook.json
@@ -8,5 +8,6 @@
     "name": "Alice Pauline",
     "phone": "94351253",
     "description": "4th street"
-  } ]
+  } ],
+  "events" : [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidEventAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidEventAddressBook.json
@@ -1,0 +1,7 @@
+{
+  "vendors" : [ ],
+  "events": [ {
+    "name": "Birthday Party",
+    "date": "10 Oct 2024"
+  } ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/invalidVendorAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidVendorAddressBook.json
@@ -2,5 +2,6 @@
   "vendors": [ {
     "name": "Hans Muster",
     "description": "4th street"
-  } ]
+  } ],
+  "events" : [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalEventsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalEventsAddressBook.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "AddressBook save file which contains the same Event values as in TypicalEvents#getTypicalAddressBook()",
+  "vendors" : [ ],
+  "events" : [ {
+    "name" : "Alice Pauline Wedding",
+    "date" : "2021-10-10"
+  }, {
+    "name" : "Benson Meier Birthday",
+    "date" : "2021-11-11"
+  }, {
+    "name" : "Carl Kurz Tea Party",
+    "date" : "2021-12-12"
+  }, {
+    "name" : "Daniel Meier Farewell",
+    "date" : "2022-01-01"
+  }, {
+    "name" : "Elle Meyer Banquet",
+    "date" : "2022-02-02"
+  }, {
+    "name" : "Fiona Kunz Reunion",
+    "date" : "2022-03-03"
+  }, {
+    "name" : "George Best Concert",
+    "date" : "2022-04-04"
+  } ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/typicalVendorsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalVendorsAddressBook.json
@@ -35,5 +35,6 @@
     "phone" : "9482442",
     "description" : "4th street",
     "tags" : [ ]
-  } ]
+  } ],
+  "events" : [ ]
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
@@ -1,0 +1,56 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.storage.JsonAdaptedEvent.MISSING_FIELD_MESSAGE_FORMAT;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalEvents.DANIEL;
+import static seedu.address.testutil.TypicalEvents.FIONA;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.event.Date;
+import seedu.address.model.event.Name;
+
+public class JsonAdaptedEventTest {
+    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_DATE = "10 Oct 2024";
+
+    private static final String VALID_NAME = FIONA.getName().toString();
+    private static final String VALID_DATE = FIONA.getDate().toString();
+
+    @Test
+    public void toModelType_validEventDetails_returnsEvent() throws Exception {
+        JsonAdaptedEvent event = new JsonAdaptedEvent(DANIEL);
+        assertEquals(DANIEL, event.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidName_throwsIllegalValueException() {
+        JsonAdaptedEvent event = new JsonAdaptedEvent(INVALID_NAME, VALID_DATE);
+        String expectedMessage = Name.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullName_throwsIllegalValueException() {
+        JsonAdaptedEvent event = new JsonAdaptedEvent(null, VALID_DATE);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidDate_throwsIllegalValueException() {
+        JsonAdaptedEvent event = new JsonAdaptedEvent(VALID_NAME, INVALID_DATE);
+        String expectedMessage = Date.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullDate_throwsIllegalValueException() {
+        JsonAdaptedEvent event = new JsonAdaptedEvent(VALID_NAME, null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
+    }
+
+}

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.AddressBook;
+import seedu.address.testutil.TypicalEvents;
 import seedu.address.testutil.TypicalVendors;
 
 public class JsonSerializableAddressBookTest {
@@ -19,6 +20,9 @@ public class JsonSerializableAddressBookTest {
     private static final Path TYPICAL_VENDORS_FILE = TEST_DATA_FOLDER.resolve("typicalVendorsAddressBook.json");
     private static final Path INVALID_VENDOR_FILE = TEST_DATA_FOLDER.resolve("invalidVendorAddressBook.json");
     private static final Path DUPLICATE_VENDOR_FILE = TEST_DATA_FOLDER.resolve("duplicateVendorAddressBook.json");
+    private static final Path TYPICAL_EVENTS_FILE = TEST_DATA_FOLDER.resolve("typicalEventsAddressBook.json");
+    private static final Path INVALID_EVENT_FILE = TEST_DATA_FOLDER.resolve("invalidEventAddressBook.json");
+    private static final Path DUPLICATE_EVENT_FILE = TEST_DATA_FOLDER.resolve("duplicateEventAddressBook.json");
 
     @Test
     public void toModelType_typicalVendorsFile_success() throws Exception {
@@ -41,6 +45,30 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_VENDOR_FILE,
                 JsonSerializableAddressBook.class).get();
         assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_VENDOR,
+                dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_typicalEventsFile_success() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_EVENTS_FILE,
+                JsonSerializableAddressBook.class).get();
+        AddressBook addressBookFromFile = dataFromFile.toModelType();
+        AddressBook typicalEventsAddressBook = TypicalEvents.getTypicalAddressBook();
+        assertEquals(addressBookFromFile, typicalEventsAddressBook);
+    }
+
+    @Test
+    public void toModelType_invalidEventFile_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(INVALID_EVENT_FILE,
+                JsonSerializableAddressBook.class).get();
+        assertThrows(IllegalValueException.class, dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_duplicateEvents_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_EVENT_FILE,
+                JsonSerializableAddressBook.class).get();
+        assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_EVENT,
                 dataFromFile::toModelType);
     }
 


### PR DESCRIPTION
Resolves #80 

### Changes
- Add `JsonAdaptedEvent`
- Update `JsonSerializableAddressBook` to store a list of `JsonAdaptedEvent` objects.
- Add tests for both classes, which includes new test `.json` files.
- Events in the address book can technically be saved into json. However, as new events cannot be added to the event list yet, this would mean the .json file would not contain events.

### Note
- Tests for `JsonAddressBookStorage` has not been updated because `CreateEventCommand` is still not functional (thanks to me).
- Tests will need to be updated to ensure that the loading the saving of both vendors and events is working as intended.