### PR TITLE
Integrate association with DetailsPanel

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -4,6 +4,8 @@ import java.nio.file.Path;
 
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -44,6 +46,9 @@ public interface Logic {
 
     /** Returns the current state of the UI */
     ObservableObjectValue<UiState> getUiState();
+
+    /** Returns a view of the associations */
+    ObservableSet<Pair<Vendor, Event>> getAssociations();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -7,6 +7,8 @@ import java.util.logging.Logger;
 
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
@@ -87,6 +89,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableObjectValue<UiState> getUiState() {
         return model.getUiState();
+    }
+
+    @Override
+    public ObservableSet<Pair<Vendor, Event>> getAssociations() {
+        return model.getAssociations();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -6,9 +6,10 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
 import javafx.util.Pair;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.event.Event;
@@ -24,7 +25,8 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniqueVendorList vendors;
     private final UniqueEventList events;
-    private final Set<Pair<Vendor, Event>> associations;
+    private final ObservableSet<Pair<Vendor, Event>> associations;
+    // private final ObservableSet<Pair<Vendor, Event>> associations;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -35,7 +37,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         vendors = new UniqueVendorList();
-        associations = new HashSet<>();
+        associations = FXCollections.observableSet(new HashSet<>());
         events = new UniqueEventList();
     }
 
@@ -182,6 +184,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public ObservableList<Event> getEventList() {
         return events.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableSet<Pair<Vendor, Event>> getAssociations() {
+        return associations;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,8 @@ import java.util.function.Predicate;
 
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
@@ -90,8 +92,8 @@ public interface Model {
     void updateFilteredVendorList(Predicate<Vendor> predicate);
 
     /**
-     * Returns true if the given {@code vendor} is already assigned to the given {@code event}.
-     * {@code vendor} and {@code event} must exist in the address book.
+     * Returns true if the given {@code vendor} is already assigned to the given {@code event}. {@code vendor} and
+     * {@code event} must exist in the address book.
      */
     boolean isVendorAssignedToEvent(Vendor vendor, Event event);
 
@@ -155,5 +157,9 @@ public interface Model {
      * @param uiState {@code UiState} object.
      */
     public void setUiState(UiState uiState);
-}
 
+    /**
+     * Returns an unmodifiable view of the associations set.
+     */
+    public ObservableSet<Pair<Vendor, Event>> getAssociations();
+}

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,7 +11,9 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
 import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.event.Event;
@@ -30,6 +32,7 @@ public class ModelManager implements Model {
     private final ObjectProperty<Vendor> selectedVendor;
     private final FilteredList<Event> filteredEvents;
     private final ObjectProperty<Event> selectedEvent;
+    private final ObservableSet<Pair<Vendor, Event>> associations;
     private final ObjectProperty<UiState> currentUiState;
 
     /**
@@ -44,6 +47,7 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredVendors = new FilteredList<>(this.addressBook.getVendorList());
         filteredEvents = new FilteredList<>(this.addressBook.getEventList());
+        associations = this.addressBook.getAssociations();
         selectedVendor = new SimpleObjectProperty<>(null);
         selectedEvent = new SimpleObjectProperty<>(null);
         currentUiState = new SimpleObjectProperty<>(UiState.DEFAULT);
@@ -241,6 +245,12 @@ public class ModelManager implements Model {
     public void setUiState(UiState uiState) {
         requireNonNull(uiState);
         currentUiState.setValue(uiState);
+    }
+
+    // =========== Association Accessors =============================================================
+    @Override
+    public ObservableSet<Pair<Vendor, Event>> getAssociations() {
+        return associations;
     }
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,8 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
+import javafx.util.Pair;
 import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 
@@ -20,5 +22,10 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate events.
      */
     ObservableList<Event> getEventList();
+
+    /**
+     * Returns an unmodifiable view of the associations set.
+     */
+    ObservableSet<Pair<Vendor, Event>> getAssociations();
 
 }

--- a/src/main/java/seedu/address/ui/EventDetailsPanel.java
+++ b/src/main/java/seedu/address/ui/EventDetailsPanel.java
@@ -3,12 +3,16 @@ package seedu.address.ui;
 import java.util.logging.Logger;
 
 import javafx.beans.value.ObservableObjectValue;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
+import javafx.collections.SetChangeListener;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import javafx.util.Pair;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
@@ -32,15 +36,26 @@ public class EventDetailsPanel extends UiPart<Region> {
     @FXML
     private StackPane detailsChildrenPlaceholder;
 
+    private ObservableList<Vendor> assignedVendors;
+
     /**
      * Creates a {@code VendorListPanel} with the given {@code ObservableList}.
      */
-    public EventDetailsPanel(ObservableObjectValue<Event> event, ObservableList<Vendor> assignedVendors) {
+    public EventDetailsPanel(ObservableObjectValue<Event> event, ObservableSet<Pair<Vendor, Event>> associations) {
         super(FXML);
+
+        assignedVendors = FXCollections.observableArrayList();
 
         event.addListener((observable, oldValue, newValue) -> {
             showEventDetails();
             setEvent(newValue);
+
+            // Update assignedVendors when event is changed
+            updateAssignedVendors(associations);
+        });
+
+        associations.addListener((SetChangeListener.Change<? extends Pair<Vendor, Event>> change) -> {
+            updateAssignedVendors(associations);
         });
 
         VendorListPanel vendorListPanel = new VendorListPanel(assignedVendors, "Assigned Vendors");
@@ -57,6 +72,12 @@ public class EventDetailsPanel extends UiPart<Region> {
     private void showEventDetails() {
         detailsHolder.setVisible(true);
         noEventMsg.setVisible(false);
+    }
+
+    private void updateAssignedVendors(ObservableSet<Pair<Vendor, Event>> associations) {
+        assignedVendors.clear();
+        assignedVendors
+                .addAll(associations.stream().filter(pair -> pair.getValue().equals(event)).map(Pair::getKey).toList());
     }
 
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -134,8 +134,8 @@ public class MainWindow extends UiPart<Stage> {
     void fillInnerParts() {
         splitView();
 
-        eventDetailsPanel = new EventDetailsPanel(logic.getViewedEvent(), logic.getFilteredVendorList());
-        vendorDetailsPanel = new VendorDetailsPanel(logic.getViewedVendor(), logic.getFilteredVendorList());
+        eventDetailsPanel = new EventDetailsPanel(logic.getViewedEvent(), logic.getAssociations());
+        vendorDetailsPanel = new VendorDetailsPanel(logic.getViewedVendor(), logic.getAssociations());
 
         vendorListPanel = new VendorListPanel(logic.getFilteredVendorList(), "Vendors List");
         leftPanelPlaceholder.getChildren().add(vendorListPanel.getRoot());

--- a/src/main/java/seedu/address/ui/VendorDetailsPanel.java
+++ b/src/main/java/seedu/address/ui/VendorDetailsPanel.java
@@ -3,13 +3,18 @@ package seedu.address.ui;
 import java.util.logging.Logger;
 
 import javafx.beans.value.ObservableObjectValue;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
+import javafx.collections.SetChangeListener;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import javafx.util.Pair;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 
 /**
@@ -33,19 +38,30 @@ public class VendorDetailsPanel extends UiPart<Region> {
     @FXML
     private StackPane detailsChildrenPlaceholder;
 
+    private ObservableList<Event> assignedEvents;
+
     /**
      * Creates a {@code VendorListPanel} with the given {@code ObservableList}.
      */
-    public VendorDetailsPanel(ObservableObjectValue<Vendor> vendor, ObservableList<Vendor> assignedEvents) {
+    public VendorDetailsPanel(ObservableObjectValue<Vendor> vendor, ObservableSet<Pair<Vendor, Event>> associations) {
         super(FXML);
+
+        assignedEvents = FXCollections.observableArrayList();
 
         vendor.addListener((observable, oldValue, newValue) -> {
             showVendorDetails();
             setVendor(newValue);
+
+            updateAssignedEvents(associations);
         });
 
-        VendorListPanel vendorListPanel = new VendorListPanel(assignedEvents, "Assigned Events");
-        detailsChildrenPlaceholder.getChildren().add(vendorListPanel.getRoot());
+        associations.addListener((SetChangeListener.Change<? extends Pair<Vendor, Event>> change) -> {
+            updateAssignedEvents(associations);
+        });
+
+        // TODO: Update to EventListPanel once implemented
+        // VendorListPanel vendorListPanel = new VendorListPanel(assignedEvents, "Assigned Events");
+        // detailsChildrenPlaceholder.getChildren().add(vendorListPanel.getRoot());
 
     }
 
@@ -59,6 +75,12 @@ public class VendorDetailsPanel extends UiPart<Region> {
     private void showVendorDetails() {
         detailsHolder.setVisible(true);
         noVendorMsg.setVisible(false);
+    }
+
+    private void updateAssignedEvents(ObservableSet<Pair<Vendor, Event>> associations) {
+        assignedEvents.clear();
+        assignedEvents.addAll(
+                associations.stream().filter(pair -> pair.getKey().equals(vendor)).map(Pair::getValue).toList());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CreateEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateEventCommandTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -222,6 +224,11 @@ public class CreateEventCommandTest {
 
         @Override
         public ObservableObjectValue<Vendor> getViewedVendor() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableSet<Pair<Vendor, Event>> getAssociations() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/CreateVendorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateVendorCommandTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.Test;
 
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -224,6 +226,11 @@ public class CreateVendorCommandTest {
 
         @Override
         public void setUiState(UiState uiState) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableSet<Pair<Vendor, Event>> getAssociations() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
+import javafx.util.Pair;
 import seedu.address.model.event.Date;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.Name;
@@ -165,6 +167,11 @@ public class AddressBookTest {
         @Override
         public ObservableList<Event> getEventList() {
             return events;
+        }
+
+        @Override
+        public ObservableSet<Pair<Vendor, Event>> getAssociations() {
+            return null;
         }
     }
 


### PR DESCRIPTION
# Summary
- Refactor `association` to be a `ObservableSet` instead of a `HashSet`
- Tunnel `association` through `Logic` and `Model`
- Update details page when creating a new association

`assign v/1 e/1`
![image](https://github.com/user-attachments/assets/e9ee6154-d380-4763-bd5f-84247ecd06ab)
