### PR TITLE
Add get associated vendors and events

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -6,7 +6,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
@@ -239,3 +238,4 @@ public class AddressBook implements ReadOnlyAddressBook {
         return Objects.hash(vendors.hashCode(), events.hashCode());
     }
 }
+

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -7,7 +7,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.util.Pair;
 import seedu.address.commons.util.ToStringBuilder;
@@ -134,6 +136,32 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireAllNonNull(vendor, event);
         Pair<Vendor, Event> pair = new Pair<>(vendor, event);
         associations.add(pair);
+    }
+
+    /**
+     * Returns list of associated vendors to an event.
+     */
+    public ObservableList<Vendor> getAssociatedVendors(Event event) {
+        requireNonNull(event);
+        List<Vendor> vendorsList = associations.stream()
+                .filter(pair -> pair.getValue().equals(event))
+                .map(Pair::getKey)
+                .collect(Collectors.toList());
+
+        return FXCollections.observableArrayList(vendorsList);
+    }
+
+    /**
+     * Returns list of associated events to a vendor.
+     */
+    public ObservableList<Event> getAssociatedEvents(Vendor vendor) {
+        requireNonNull(vendor);
+        List<Event> eventsList = associations.stream()
+                .filter(pair -> pair.getKey().equals(vendor))
+                .map(Pair::getValue)
+                .collect(Collectors.toList());
+
+        return FXCollections.observableArrayList(eventsList);
     }
 
     //// event-level operations

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -101,6 +101,16 @@ public interface Model {
     void assignVendorToEvent(Vendor vendor, Event event);
 
     /**
+     * Returns list of associated vendors to an event.
+     */
+    ObservableList<Vendor> getAssociatedVendors(Event event);
+
+    /**
+     * Returns list of associated events to a vendor.
+     */
+    ObservableList<Event> getAssociatedEvents(Vendor vendor);
+
+    /**
      * Returns the current selected vendor.
      */
     ObservableObjectValue<Vendor> getViewedVendor();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -124,7 +124,7 @@ public class ModelManager implements Model {
         addressBook.setVendor(target, editedVendor);
     }
 
-    // =========== Filtered Vendor List Accessors =============================================================
+    // =========== Assigning vendors and events =============================================================
     @Override
     public boolean isVendorAssignedToEvent(Vendor vendor, Event event) {
         requireAllNonNull(vendor, event);
@@ -135,6 +135,18 @@ public class ModelManager implements Model {
     public void assignVendorToEvent(Vendor vendor, Event event) {
         requireAllNonNull(vendor, event);
         addressBook.assignVendorToEvent(vendor, event);
+    }
+
+    @Override
+    public ObservableList<Event> getAssociatedEvents(Vendor vendor) {
+        requireNonNull(vendor);
+        return addressBook.getAssociatedEvents(vendor);
+    }
+
+    @Override
+    public ObservableList<Vendor> getAssociatedVendors(Event event) {
+        requireNonNull(event);
+        return addressBook.getAssociatedVendors(event);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -124,6 +124,23 @@ public class ModelManager implements Model {
         addressBook.setVendor(target, editedVendor);
     }
 
+    @Override
+    public boolean hasEvent(Event event) {
+        requireNonNull(event);
+        return addressBook.hasEvent(event);
+    }
+
+    @Override
+    public void deleteEvent(Event target) {
+        addressBook.removeEvent(target);
+    }
+
+    @Override
+    public void addEvent(Event event) {
+        addressBook.addEvent(event);
+        updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
+    }
+
     // =========== Assigning vendors and events =============================================================
     @Override
     public boolean isVendorAssignedToEvent(Vendor vendor, Event event) {
@@ -147,23 +164,6 @@ public class ModelManager implements Model {
     public ObservableList<Vendor> getAssociatedVendors(Event event) {
         requireNonNull(event);
         return addressBook.getAssociatedVendors(event);
-    }
-
-    @Override
-    public boolean hasEvent(Event event) {
-        requireNonNull(event);
-        return addressBook.hasEvent(event);
-    }
-
-    @Override
-    public void deleteEvent(Event target) {
-        addressBook.removeEvent(target);
-    }
-
-    @Override
-    public void addEvent(Event event) {
-        addressBook.addEvent(event);
-        updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
     }
 
     // =========== Filtered Vendor List Accessors =============================================================

--- a/src/test/java/seedu/address/logic/commands/CreateEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateEventCommandTest.java
@@ -186,12 +186,22 @@ public class CreateEventCommandTest {
         }
 
         @Override
+        public boolean isVendorAssignedToEvent(Vendor vendor, Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void assignVendorToEvent(Vendor vendor, Event event) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public boolean isVendorAssignedToEvent(Vendor vendor, Event event) {
+        public ObservableList<Vendor> getAssociatedVendors(Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Event> getAssociatedEvents(Vendor vendor) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CreateVendorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateVendorCommandTest.java
@@ -208,6 +208,16 @@ public class CreateVendorCommandTest {
         }
 
         @Override
+        public ObservableList<Vendor> getAssociatedVendors(Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Event> getAssociatedEvents(Vendor vendor) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableObjectValue<Event> getViewedEvent() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BOB
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalVendors.ALICE;
+import static seedu.address.testutil.TypicalVendors.BOB;
 import static seedu.address.testutil.TypicalVendors.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -30,6 +31,7 @@ public class AddressBookTest {
 
     private final AddressBook addressBook = new AddressBook();
     private final Event testEvent = new Event(new Name("Test Event"), new Date("2024-10-11"));
+    private final Event anotherEvent = new Event(new Name("Another Event"), new Date("2024-10-11"));
     private final Event similarTestEvent = new Event(new Name("Test Event"), new Date("2023-05-20"));
 
     @Test
@@ -143,6 +145,46 @@ public class AddressBookTest {
                 + "events=" + addressBook.getEventList()
                 + "}";
         assertEquals(expected, addressBook.toString());
+    }
+
+    @Test
+    public void getAssociatedVendors_noAssociations_returnsEmptyList() {
+        ObservableList<Vendor> associatedVendors = addressBook.getAssociatedVendors(testEvent);
+        assertEquals(FXCollections.observableArrayList(), associatedVendors);
+    }
+
+    @Test
+    public void getAssociatedVendors_withAssociations_returnsCorrectVendors() {
+        addressBook.addVendor(ALICE);
+        addressBook.addVendor(BOB);
+        addressBook.addEvent(testEvent);
+        addressBook.assignVendorToEvent(ALICE, testEvent);
+        addressBook.assignVendorToEvent(BOB, testEvent);
+
+        ObservableList<Vendor> associatedVendors = addressBook.getAssociatedVendors(testEvent);
+        ObservableList<Vendor> expectedVendors = FXCollections.observableArrayList(BOB, ALICE);
+
+        assertEquals(expectedVendors, associatedVendors);
+    }
+
+    @Test
+    public void getAssociatedEvents_noAssociations_returnsEmptyList() {
+        ObservableList<Event> associatedEvents = addressBook.getAssociatedEvents(ALICE);
+        assertEquals(FXCollections.observableArrayList(), associatedEvents);
+    }
+
+    @Test
+    public void getAssociatedEvents_withAssociations_returnsCorrectEvents() {
+        addressBook.addVendor(ALICE);
+        addressBook.addEvent(testEvent);
+        addressBook.addEvent(anotherEvent);
+        addressBook.assignVendorToEvent(ALICE, testEvent);
+        addressBook.assignVendorToEvent(ALICE, anotherEvent);
+
+        ObservableList<Event> associatedEvents = addressBook.getAssociatedEvents(ALICE);
+        ObservableList<Event> expectedEvents = FXCollections.observableArrayList(anotherEvent, testEvent);
+
+        assertEquals(expectedEvents, associatedEvents);
     }
 
     /**

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -269,3 +269,4 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
     }
 }
+

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.Test;
 
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.event.Date;
 import seedu.address.model.event.Event;
@@ -31,6 +33,7 @@ public class ModelManagerTest {
 
     private ModelManager modelManager = new ModelManager();
     private final Event testEvent = new Event(new Name("Test Event"), new Date("2024-10-11"));
+    private final Event anotherEvent = new EventBuilder().withName("Another Event").build();
 
     @Test
     public void constructor() {
@@ -172,6 +175,46 @@ public class ModelManagerTest {
 
         modelManager.viewVendor(vendor2);
         assertEquals(vendor2, observedState.get());
+    }
+
+    @Test
+    public void getAssociatedVendors_noAssociations_returnsEmptyList() {
+        ObservableList<Vendor> associatedVendors = modelManager.getAssociatedVendors(testEvent);
+        assertEquals(FXCollections.observableArrayList(), associatedVendors);
+    }
+
+    @Test
+    public void getAssociatedVendors_withAssociations_returnsCorrectVendors() {
+        modelManager.addVendor(ALICE);
+        modelManager.addVendor(BENSON);
+        modelManager.addEvent(testEvent);
+        modelManager.assignVendorToEvent(ALICE, testEvent);
+        modelManager.assignVendorToEvent(BENSON, testEvent);
+
+        ObservableList<Vendor> associatedVendors = modelManager.getAssociatedVendors(testEvent);
+        ObservableList<Vendor> expectedVendors = FXCollections.observableArrayList(BENSON, ALICE);
+
+        assertEquals(expectedVendors, associatedVendors);
+    }
+
+    @Test
+    public void getAssociatedEvents_noAssociations_returnsEmptyList() {
+        ObservableList<Event> associatedEvents = modelManager.getAssociatedEvents(ALICE);
+        assertEquals(FXCollections.observableArrayList(), associatedEvents);
+    }
+
+    @Test
+    public void getAssociatedEvents_withAssociations_returnsCorrectEvents() {
+        modelManager.addVendor(ALICE);
+        modelManager.addEvent(testEvent);
+        modelManager.addEvent(anotherEvent);
+        modelManager.assignVendorToEvent(ALICE, testEvent);
+        modelManager.assignVendorToEvent(ALICE, anotherEvent);
+
+        ObservableList<Event> associatedEvents = modelManager.getAssociatedEvents(ALICE);
+        ObservableList<Event> expectedEvents = FXCollections.observableArrayList(anotherEvent, testEvent);
+
+        assertEquals(expectedEvents, associatedEvents);
     }
 
     @Test


### PR DESCRIPTION
Add methods to `AddressBook`, `ModelManager` and `Model` to get the list of associated vendors and events. Resolves #98.