### PR TITLE
Update delete command to display failure message for associated event/vendor

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -25,7 +25,7 @@ public class DeleteEventCommand extends DeleteCommand {
             + "Example: " + COMMAND_WORD + " " + PREFIX_EVENT + "1";
 
     public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Deleted Event: %1$s";
-    public static final String MESSAGE_DELETE_EVENT_ASSOCIATED_FAILURE =
+    public static final String MESSAGE_DELETE_EVENT_FAILED_DUE_TO_EXISTING_ASSOCIATIONS =
         "Deletion failed as vendors are assigned to Event: %1$s";
 
     /**
@@ -53,7 +53,7 @@ public class DeleteEventCommand extends DeleteCommand {
         try {
             model.deleteEvent(eventToDelete);
         } catch (AssociationDeleteException ae) {
-            throw new CommandException(String.format(MESSAGE_DELETE_EVENT_ASSOCIATED_FAILURE,
+            throw new CommandException(String.format(MESSAGE_DELETE_EVENT_FAILED_DUE_TO_EXISTING_ASSOCIATIONS,
                 Messages.format(eventToDelete)));
         }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -8,8 +8,8 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.commons.exceptions.AssociationDeleteException;
 import seedu.address.model.Model;
+import seedu.address.model.commons.exceptions.AssociationDeleteException;
 import seedu.address.model.event.Event;
 
 /**
@@ -53,7 +53,8 @@ public class DeleteEventCommand extends DeleteCommand {
         try {
             model.deleteEvent(eventToDelete);
         } catch (AssociationDeleteException ae) {
-            return new CommandResult(String.format(MESSAGE_DELETE_EVENT_ASSOCIATED_FAILURE, Messages.format(eventToDelete)));
+            return new CommandResult(String.format(MESSAGE_DELETE_EVENT_ASSOCIATED_FAILURE,
+                Messages.format(eventToDelete)));
         }
 
         return new CommandResult(String.format(MESSAGE_DELETE_EVENT_SUCCESS, Messages.format(eventToDelete)));

--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.commons.exceptions.AssociationDeleteException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
 
@@ -24,6 +25,8 @@ public class DeleteEventCommand extends DeleteCommand {
             + "Example: " + COMMAND_WORD + " " + PREFIX_EVENT + "1";
 
     public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Deleted Event: %1$s";
+    public static final String MESSAGE_DELETE_EVENT_ASSOCIATED_FAILURE =
+        "Deletion failed as vendors are assigned to Event: %1$s";
 
     /**
      * Creates a DeleteEventCommand to delete the event at the specified
@@ -46,7 +49,13 @@ public class DeleteEventCommand extends DeleteCommand {
         }
 
         Event eventToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deleteEvent(eventToDelete);
+
+        try {
+            model.deleteEvent(eventToDelete);
+        } catch (AssociationDeleteException ae) {
+            return new CommandResult(String.format(MESSAGE_DELETE_EVENT_ASSOCIATED_FAILURE, Messages.format(eventToDelete)));
+        }
+
         return new CommandResult(String.format(MESSAGE_DELETE_EVENT_SUCCESS, Messages.format(eventToDelete)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -53,7 +53,7 @@ public class DeleteEventCommand extends DeleteCommand {
         try {
             model.deleteEvent(eventToDelete);
         } catch (AssociationDeleteException ae) {
-            return new CommandResult(String.format(MESSAGE_DELETE_EVENT_ASSOCIATED_FAILURE,
+            throw new CommandException(String.format(MESSAGE_DELETE_EVENT_ASSOCIATED_FAILURE,
                 Messages.format(eventToDelete)));
         }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteVendorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteVendorCommand.java
@@ -53,7 +53,7 @@ public class DeleteVendorCommand extends DeleteCommand {
         try {
             model.deleteVendor(vendorToDelete);
         } catch (AssociationDeleteException ae) {
-            return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_ASSOCIATED_FAILURE,
+            throw new CommandException(String.format(MESSAGE_DELETE_VENDOR_ASSOCIATED_FAILURE,
                 Messages.format(vendorToDelete)));
         }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteVendorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteVendorCommand.java
@@ -25,7 +25,7 @@ public class DeleteVendorCommand extends DeleteCommand {
             + "Example: " + COMMAND_WORD + " " + PREFIX_VENDOR + "1";
 
     public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
-    public static final String MESSAGE_DELETE_VENDOR_ASSOCIATED_FAILURE =
+    public static final String DELETE_VENDOR_FAILED_DUE_TO_EXISTING_ASSOCIATIONS =
         "Deletion failed as Vendor: %1$s is assigned to event(s)";
 
     /**
@@ -53,7 +53,7 @@ public class DeleteVendorCommand extends DeleteCommand {
         try {
             model.deleteVendor(vendorToDelete);
         } catch (AssociationDeleteException ae) {
-            throw new CommandException(String.format(MESSAGE_DELETE_VENDOR_ASSOCIATED_FAILURE,
+            throw new CommandException(String.format(DELETE_VENDOR_FAILED_DUE_TO_EXISTING_ASSOCIATIONS,
                 Messages.format(vendorToDelete)));
         }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteVendorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteVendorCommand.java
@@ -8,8 +8,8 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.commons.exceptions.AssociationDeleteException;
 import seedu.address.model.Model;
+import seedu.address.model.commons.exceptions.AssociationDeleteException;
 import seedu.address.model.vendor.Vendor;
 
 /**
@@ -53,7 +53,8 @@ public class DeleteVendorCommand extends DeleteCommand {
         try {
             model.deleteVendor(vendorToDelete);
         } catch (AssociationDeleteException ae) {
-            return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_ASSOCIATED_FAILURE, Messages.format(vendorToDelete)));
+            return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_ASSOCIATED_FAILURE,
+                Messages.format(vendorToDelete)));
         }
 
         return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_SUCCESS, Messages.format(vendorToDelete)));

--- a/src/main/java/seedu/address/logic/commands/DeleteVendorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteVendorCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.commons.exceptions.AssociationDeleteException;
 import seedu.address.model.Model;
 import seedu.address.model.vendor.Vendor;
 
@@ -24,6 +25,8 @@ public class DeleteVendorCommand extends DeleteCommand {
             + "Example: " + COMMAND_WORD + " " + PREFIX_VENDOR + "1";
 
     public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
+    public static final String MESSAGE_DELETE_VENDOR_ASSOCIATED_FAILURE =
+        "Deletion failed as Vendor: %1$s is assigned to event(s)";
 
     /**
      * Creates a DeleteVendorCommand to delete the vendor at the specified
@@ -46,7 +49,13 @@ public class DeleteVendorCommand extends DeleteCommand {
         }
 
         Vendor vendorToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deleteVendor(vendorToDelete);
+
+        try {
+            model.deleteVendor(vendorToDelete);
+        } catch (AssociationDeleteException ae) {
+            return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_ASSOCIATED_FAILURE, Messages.format(vendorToDelete)));
+        }
+
         return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_SUCCESS, Messages.format(vendorToDelete)));
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -13,6 +13,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.ObservableSet;
 import javafx.util.Pair;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.commons.exceptions.AssociationDeleteException;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.UniqueEventList;
 import seedu.address.model.vendor.UniqueVendorList;
@@ -112,8 +113,12 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
+     * @throws VendorDeleteException if the vendor is not deletable (e.g. it is associated with an event)
      */
-    public void removeVendor(Vendor key) {
+    public void removeVendor(Vendor key) throws AssociationDeleteException {
+        if (getAssociatedEvents(key).size() > 0) {
+            throw new AssociationDeleteException();
+        }
         vendors.remove(key);
     }
 
@@ -188,8 +193,12 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
+     * @throws EventDeleteException if the event is not deletable (e.g. it is associated with a vendor)
      */
-    public void removeEvent(Event key) {
+    public void removeEvent(Event key) throws AssociationDeleteException {
+        if (getAssociatedVendors(key).size() > 0) {
+            throw new AssociationDeleteException();
+        }
         events.remove(key);
     }
 
@@ -238,4 +247,3 @@ public class AddressBook implements ReadOnlyAddressBook {
         return Objects.hash(vendors.hashCode(), events.hashCode());
     }
 }
-

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -113,10 +113,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
-     * @throws VendorDeleteException if the vendor is not deletable (e.g. it is associated with an event)
+     * @throws AssociationDeleteException if the vendor is not deletable (e.g. it is associated with an event)
      */
     public void removeVendor(Vendor key) throws AssociationDeleteException {
-        if (getAssociatedEvents(key).size() > 0) {
+        final boolean isVendorAssignedToAnyEvent = getAssociatedEvents(key).size() > 0;
+        if (isVendorAssignedToAnyEvent) {
             throw new AssociationDeleteException();
         }
         vendors.remove(key);
@@ -203,10 +204,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
-     * @throws EventDeleteException if the event is not deletable (e.g. it is associated with a vendor)
+     * @throws AssociationDeleteException if the event is not deletable (e.g. it is associated with a vendor)
      */
     public void removeEvent(Event key) throws AssociationDeleteException {
-        if (getAssociatedVendors(key).size() > 0) {
+        final boolean isEventAssignedToAnyVendor = getAssociatedVendors(key).size() > 0;
+        if (isEventAssignedToAnyVendor) {
             throw new AssociationDeleteException();
         }
         events.remove(key);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -8,6 +8,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.ObservableSet;
 import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.commons.exceptions.AssociationDeleteException;
 import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 import seedu.address.ui.UiState;
@@ -68,7 +69,7 @@ public interface Model {
     /**
      * Deletes the given vendor. The vendor must exist in the address book.
      */
-    void deleteVendor(Vendor target);
+    void deleteVendor(Vendor target) throws AssociationDeleteException;
 
     /**
      * Adds the given vendor. {@code vendor} must not already exist in the address book.
@@ -130,7 +131,7 @@ public interface Model {
     /**
      * Deletes the given event. The event must exist in the address book.
      */
-    void deleteEvent(Event target);
+    void deleteEvent(Event target) throws AssociationDeleteException;
 
     /**
      * Adds the given event. {@code event} must not already exist in the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -16,6 +16,7 @@ import javafx.collections.transformation.FilteredList;
 import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.commons.exceptions.AssociationDeleteException;
 import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 import seedu.address.ui.UiState;
@@ -111,7 +112,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void deleteVendor(Vendor target) {
+    public void deleteVendor(Vendor target) throws AssociationDeleteException {
         addressBook.removeVendor(target);
     }
 
@@ -135,7 +136,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void deleteEvent(Event target) {
+    public void deleteEvent(Event target) throws AssociationDeleteException {
         addressBook.removeEvent(target);
     }
 

--- a/src/main/java/seedu/address/model/commons/exceptions/AssociationDeleteException.java
+++ b/src/main/java/seedu/address/model/commons/exceptions/AssociationDeleteException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.commons.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified vendor.
+ */
+public class AssociationDeleteException extends RuntimeException {}

--- a/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
@@ -87,7 +87,8 @@ public class DeleteEventCommandTest {
         model.assignVendorToEvent(vendorToAssign, eventToDelete);
         DeleteEventCommand deleteCommand = new DeleteEventCommand(INDEX_FIRST_EVENT);
 
-        String expectedMessage = String.format(DeleteEventCommand.MESSAGE_DELETE_EVENT_ASSOCIATED_FAILURE,
+        String expectedMessage = String.format(
+            DeleteEventCommand.MESSAGE_DELETE_EVENT_FAILED_DUE_TO_EXISTING_ASSOCIATIONS,
                 Messages.format(eventToDelete));
 
         assertCommandFailure(deleteCommand, model, expectedMessage);

--- a/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
@@ -5,9 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showEventAtIndex;
-import static seedu.address.testutil.TypicalEvents.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EVENT;
+import static seedu.address.testutil.TypicalVendorsEventsCombined.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +18,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.Event;
+import seedu.address.model.vendor.Vendor;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -76,6 +78,19 @@ public class DeleteEventCommandTest {
         DeleteEventCommand deleteCommand = new DeleteEventCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_associatedEvent_throwsCommandException() {
+        Event eventToDelete = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        Vendor vendorToAssign = model.getFilteredVendorList().get(INDEX_FIRST_VENDOR.getZeroBased());
+        model.assignVendorToEvent(vendorToAssign, eventToDelete);
+        DeleteEventCommand deleteCommand = new DeleteEventCommand(INDEX_FIRST_EVENT);
+
+        String expectedMessage = String.format(DeleteEventCommand.MESSAGE_DELETE_EVENT_ASSOCIATED_FAILURE,
+                Messages.format(eventToDelete));
+
+        assertCommandFailure(deleteCommand, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteVendorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteVendorCommandTest.java
@@ -5,9 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showVendorAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_VENDOR;
-import static seedu.address.testutil.TypicalVendors.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalVendorsEventsCombined.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +17,7 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.event.Event;
 import seedu.address.model.vendor.Vendor;
 
 /**
@@ -76,6 +78,20 @@ public class DeleteVendorCommandTest {
         DeleteVendorCommand deleteCommand = new DeleteVendorCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_associatedVendor_throwsCommandException() {
+        Vendor vendorToDelete = model.getFilteredVendorList().get(INDEX_FIRST_VENDOR.getZeroBased());
+        Event eventToAssignTo = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        model.assignVendorToEvent(vendorToDelete, eventToAssignTo);
+
+        DeleteVendorCommand deleteCommand = new DeleteVendorCommand(INDEX_FIRST_VENDOR);
+
+        String expectedMessage = String.format(DeleteVendorCommand.MESSAGE_DELETE_VENDOR_ASSOCIATED_FAILURE,
+                Messages.format(vendorToDelete));
+
+        assertCommandFailure(deleteCommand, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteVendorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteVendorCommandTest.java
@@ -88,7 +88,7 @@ public class DeleteVendorCommandTest {
 
         DeleteVendorCommand deleteCommand = new DeleteVendorCommand(INDEX_FIRST_VENDOR);
 
-        String expectedMessage = String.format(DeleteVendorCommand.MESSAGE_DELETE_VENDOR_ASSOCIATED_FAILURE,
+        String expectedMessage = String.format(DeleteVendorCommand.DELETE_VENDOR_FAILED_DUE_TO_EXISTING_ASSOCIATIONS,
                 Messages.format(vendorToDelete));
 
         assertCommandFailure(deleteCommand, model, expectedMessage);

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -21,6 +21,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableSet;
 import javafx.util.Pair;
+import seedu.address.model.commons.exceptions.AssociationDeleteException;
 import seedu.address.model.event.Date;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.Name;
@@ -147,6 +148,38 @@ public class AddressBookTest {
                 + "events=" + addressBook.getEventList()
                 + "}";
         assertEquals(expected, addressBook.toString());
+    }
+
+    @Test
+    public void removeVendor_vendorNotAssociated_success() {
+        addressBook.addVendor(ALICE);
+        addressBook.removeVendor(ALICE);
+        assertFalse(addressBook.hasVendor(ALICE));
+    }
+
+    @Test
+    public void removeVendor_vendorIsAssociatedWithEvent_throwsAssociationDeleteException() {
+        addressBook.addVendor(ALICE);
+        addressBook.addEvent(testEvent);
+        addressBook.assignVendorToEvent(ALICE, testEvent);
+
+        assertThrows(AssociationDeleteException.class, () -> addressBook.removeVendor(ALICE));
+    }
+
+    @Test
+    public void removeEvent_eventNotAssociated_success() {
+        addressBook.addEvent(testEvent);
+        addressBook.removeEvent(testEvent);
+        assertFalse(addressBook.hasEvent(testEvent));
+    }
+
+    @Test
+    public void removeEvent_eventIsAssociatedWithVendor_throwsAssociationDeleteException() {
+        addressBook.addVendor(ALICE);
+        addressBook.addEvent(testEvent);
+        addressBook.assignVendorToEvent(ALICE, testEvent);
+
+        assertThrows(AssociationDeleteException.class, () -> addressBook.removeEvent(testEvent));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalVendorsEventsCombined.java
+++ b/src/test/java/seedu/address/testutil/TypicalVendorsEventsCombined.java
@@ -1,0 +1,29 @@
+package seedu.address.testutil;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.event.Event;
+import seedu.address.model.vendor.Vendor;
+
+/**
+ * A utility class containing a list of {@code Event} and a list of {@code Vendor} objects to be used in
+ * tests.
+ */
+public class TypicalVendorsEventsCombined {
+
+    private TypicalVendorsEventsCombined() {
+    } // prevents instantiation
+
+    /**
+     * Returns an {@code AddressBook} with all the typical events and vendors.
+     */
+    public static AddressBook getTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Event event : TypicalEvents.getTypicalEvents()) {
+            ab.addEvent(event);
+        }
+        for (Vendor vendor : TypicalVendors.getTypicalVendors()) {
+            ab.addVendor(vendor);
+        }
+        return ab;
+    }
+}


### PR DESCRIPTION
- Created a new exception under `model/commons/exceptions` for handling associated delete fails
   - could be made to inherit from a parent delete exception class but don't see a need to
- Update delete commands to display error msg when trying to delete an associated event/model
   - does not show which event it is associated to, just whether it is associated to any
  