### PR TITLE
Standardize and update message usage descriptors

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CreateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateCommand.java
@@ -1,6 +1,11 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 
 /**
@@ -13,7 +18,15 @@ public abstract class CreateCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Creates a vendor or event and adds it to the list.\n"
-            + "Parameters: " + PREFIX_VENDOR + "<empty> or " + PREFIX_EVENT + "<empty>" + "\n"
-            + "Example to create a vendor: " + COMMAND_WORD + " " + PREFIX_VENDOR + " <other vendor parameters>\n"
-            + "Example to create an event: " + COMMAND_WORD + " " + PREFIX_EVENT + " <other event parameters>";
+            + "Parameters: " + PREFIX_VENDOR + " <other vendor parameters> or "
+            + PREFIX_EVENT + " <other event parameters>" + "\n"
+            + "Example to create a vendor: " + COMMAND_WORD + " " + PREFIX_VENDOR + " "
+            + PREFIX_NAME + "Adam's Bakery "
+            + PREFIX_PHONE + "98765432 "
+            + PREFIX_DESCRIPTION + "Pastries and cakes, bake in a day "
+            + PREFIX_TAG + "pastry "
+            + PREFIX_TAG + "fast" + "\n"
+            + "Example to create an event: " + COMMAND_WORD + " " + PREFIX_EVENT + " "
+            + PREFIX_NAME + "John Baby Shower" + " "
+            + PREFIX_DATE + "2021-10-10";
 }

--- a/src/main/java/seedu/address/logic/commands/CreateEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateEventCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.event.Event;
 public class CreateEventCommand extends CreateCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a new event in the address book.\n"
             + "Parameters: "
-            + PREFIX_EVENT + "<empty> "
+            + PREFIX_EVENT + " "
             + PREFIX_NAME + "NAME "
             + PREFIX_DATE + "DATE" + "\n"
             + "Example: "

--- a/src/main/java/seedu/address/logic/commands/CreateEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateEventCommand.java
@@ -19,7 +19,11 @@ public class CreateEventCommand extends CreateCommand {
             + "Parameters: "
             + PREFIX_EVENT + "<empty> "
             + PREFIX_NAME + "NAME "
-            + PREFIX_DATE + "DATE";
+            + PREFIX_DATE + "DATE" + "\n"
+            + "Example: "
+            + COMMAND_WORD + " " + PREFIX_EVENT + " "
+            + PREFIX_NAME + "John Baby Shower "
+            + PREFIX_DATE + "2021-10-10";
 
     public static final String MESSAGE_SUCCESS = "New event created: %1$s";
     public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/CreateVendorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateVendorCommand.java
@@ -26,7 +26,7 @@ public class CreateVendorCommand extends CreateCommand {
             + PREFIX_DESCRIPTION + "DESCRIPTION "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: "
-            + COMMAND_WORD + " "
+            + COMMAND_WORD + " " + PREFIX_VENDOR + " "
             + PREFIX_NAME + "Adam's Bakery "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_DESCRIPTION + "Pastries and cakes, bake in a day "

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -16,8 +16,10 @@ public abstract class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the item identified by the index number used in the displayed item list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " <" + PREFIX_VENDOR + " OR " + PREFIX_EVENT + ">" + "1";
+            + "Parameters: " + PREFIX_VENDOR + " INDEX or "
+            + PREFIX_EVENT + " INDEX (must be a positive integer)" + "\n"
+            + "Example to delete a vendor: " + COMMAND_WORD + " " + PREFIX_VENDOR + " 1" + "\n"
+            + "Example to delete an event: " + COMMAND_WORD + " " + PREFIX_EVENT + " 1" + "\n";
 
     protected final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -17,7 +17,7 @@ public abstract class DeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the item identified by the index number used in the displayed item list.\n"
             + "Parameters: " + PREFIX_VENDOR + " INDEX or "
-            + PREFIX_EVENT + " INDEX (must be a positive integer)" + "\n"
+            + PREFIX_EVENT + " INDEX (INDEX must be a positive integer)" + "\n"
             + "Example to delete a vendor: " + COMMAND_WORD + " " + PREFIX_VENDOR + " 1" + "\n"
             + "Example to delete an event: " + COMMAND_WORD + " " + PREFIX_EVENT + " 1" + "\n";
 

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -16,7 +16,7 @@ public abstract class ViewCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Views the item identified by the index number used in the displayed item list.\n"
             + "Parameters: " + PREFIX_VENDOR + " INDEX or "
-            + PREFIX_EVENT + " INDEX (must be a positive integer)" + "\n"
+            + PREFIX_EVENT + " INDEX (INDEX must be a positive integer)" + "\n"
             + "Example to delete a vendor: " + COMMAND_WORD + " " + PREFIX_VENDOR + " 1" + "\n"
             + "Example to delete an event: " + COMMAND_WORD + " " + PREFIX_EVENT + " 1" + "\n";
 

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -15,8 +15,10 @@ public abstract class ViewCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Views the item identified by the index number used in the displayed item list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n" + "Example: " + COMMAND_WORD + " <" + PREFIX_VENDOR
-            + " OR " + PREFIX_EVENT + ">" + "1";
+            + "Parameters: " + PREFIX_VENDOR + " INDEX or "
+            + PREFIX_EVENT + " INDEX (must be a positive integer)" + "\n"
+            + "Example to delete a vendor: " + COMMAND_WORD + " " + PREFIX_VENDOR + " 1" + "\n"
+            + "Example to delete an event: " + COMMAND_WORD + " " + PREFIX_EVENT + " 1" + "\n";
 
     protected final Index targetIndex;
 


### PR DESCRIPTION
- Standardize separate examples for both vendor and event
- Parameters can still use `<v/ OR e/>`
- Add examples for `createCommand` and `createEventCommand`

Resolves: #124 