### PR TITLE
Add highlight to focused elements

### DIFF
--- a/src/main/java/seedu/eventtory/ui/EventDetailsPanel.java
+++ b/src/main/java/seedu/eventtory/ui/EventDetailsPanel.java
@@ -78,6 +78,7 @@ public class EventDetailsPanel extends UiPart<Region> {
             date.setText(event.getDate().toString());
             // Empty tags will leave behind the last set of tags,
             // so we clear the tags before adding new tags
+            tags.getChildren().clear();
             event.getTags().stream().sorted(Comparator.comparing(tag -> tag.tagName))
                     .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         } else {

--- a/src/main/java/seedu/eventtory/ui/EventListPanel.java
+++ b/src/main/java/seedu/eventtory/ui/EventListPanel.java
@@ -31,6 +31,13 @@ public class EventListPanel extends UiPart<Region> {
         eventListView.setItems(eventList);
         eventListView.setCellFactory(listView -> new EventListViewCell());
         header.setText(headerText);
+
+        // Required to fix the issue of last item not being shown when scrolled to the end
+        eventListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue != null) {
+                eventListView.scrollTo(eventListView.getSelectionModel().getSelectedIndex());
+            }
+        });
     }
 
     /**

--- a/src/main/java/seedu/eventtory/ui/MainWindow.java
+++ b/src/main/java/seedu/eventtory/ui/MainWindow.java
@@ -223,6 +223,7 @@ public class MainWindow extends UiPart<Stage> {
         vendorListPanel.setHeader(VENDOR_LIST_HEADER);
         leftPanelPlaceholder.getChildren().clear();
         leftPanelPlaceholder.getChildren().add(vendorListPanel.getRoot());
+        rightPanelPlaceholder.getChildren().clear();
     }
 
     /**
@@ -233,6 +234,7 @@ public class MainWindow extends UiPart<Stage> {
         eventListPanel.setHeader(EVENT_LIST_HEADER);
         leftPanelPlaceholder.getChildren().clear();
         leftPanelPlaceholder.getChildren().add(eventListPanel.getRoot());
+        rightPanelPlaceholder.getChildren().clear();
     }
 
     /**

--- a/src/main/java/seedu/eventtory/ui/VendorDetailsPanel.java
+++ b/src/main/java/seedu/eventtory/ui/VendorDetailsPanel.java
@@ -82,6 +82,7 @@ public class VendorDetailsPanel extends UiPart<Region> {
             description.setText(vendor.getDescription().value);
             // Empty tags will leave behind the last set of tags,
             // so we clear the tags before adding new tags
+            tags.getChildren().clear();
             vendor.getTags().stream().sorted(Comparator.comparing(tag -> tag.tagName))
                     .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         } else {

--- a/src/main/java/seedu/eventtory/ui/VendorListPanel.java
+++ b/src/main/java/seedu/eventtory/ui/VendorListPanel.java
@@ -31,6 +31,13 @@ public class VendorListPanel extends UiPart<Region> {
         vendorListView.setItems(vendorList);
         vendorListView.setCellFactory(listView -> new VendorListViewCell());
         header.setText(headerText);
+
+        // Required to fix the issue of last item not being shown when scrolled to the end
+        vendorListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue != null) {
+                vendorListView.scrollTo(vendorListView.getSelectionModel().getSelectedIndex());
+            }
+        });
     }
 
     /**

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -3,7 +3,6 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..." styleClass="focusable" stylesheets="@Extensions.css" />
 </StackPane>
-

--- a/src/main/resources/view/EventListPanel.fxml
+++ b/src/main/resources/view/EventListPanel.fxml
@@ -14,5 +14,5 @@
             <Insets bottom="15.0" left="15.0" top="15.0" />
         </padding>
     </Label>
-    <ListView fx:id="eventListView" VBox.vgrow="ALWAYS" />
+    <ListView fx:id="eventListView" styleClass="focusable" stylesheets="@Extensions.css" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -3,6 +3,17 @@
     -fx-text-fill: #d06651 !important; /* The error class should always override the default text-fill style */
 }
 
+.focusable {
+    -fx-border-color: transparent !important;
+    -fx-border-width: 2 !important;
+    -fx-border-style: solid !important;
+    -fx-border-radius: 3 !important;
+}
+
+.focusable:focused {
+    -fx-border-color: #4d91fe !important;
+}
+
 .list-cell:empty {
     /* Empty cells will not have alternating colours */
     -fx-background: #383838;

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,7 +3,6 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/17"
-    xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+  <TextArea fx:id="resultDisplay" editable="false" focusTraversable="false" styleClass="result-display" />
 </StackPane>

--- a/src/main/resources/view/VendorListPanel.fxml
+++ b/src/main/resources/view/VendorListPanel.fxml
@@ -14,5 +14,5 @@
          <Insets bottom="15.0" left="15.0" top="15.0" />
       </padding>
    </Label>
-  <ListView fx:id="vendorListView" VBox.vgrow="ALWAYS" />
+  <ListView fx:id="vendorListView" styleClass="focusable" stylesheets="@Extensions.css" VBox.vgrow="ALWAYS" />
 </VBox>


### PR DESCRIPTION
# Summary

It is possible to tab to focus on the different elements and use the arrow keys to scroll, but it was not possible to find out what was focused.

- Add highlights to show focused elements

# View
![ScreenRecording2024-11-01174819-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/995e84c0-cabe-4296-916e-636bc3098527)
