### PR TITLE
Add trailing indexing scheme in view mode

### DIFF
--- a/src/main/java/seedu/eventtory/logic/Logic.java
+++ b/src/main/java/seedu/eventtory/logic/Logic.java
@@ -60,10 +60,10 @@ public interface Logic {
     ObservableList<Association> getAssociationList();
 
     /** Return the display index of the first vendor in the assigned list */
-    ObservableIntegerValue getAssignedVendorsDisplayStartIdx();
+    ObservableIntegerValue getStartingIndexOfAssignedVendors();
 
     /** Return the display index of the first event in the assigned list */
-    ObservableIntegerValue getAssignedEventsDisplayStartIdx();
+    ObservableIntegerValue getStartingIndexOfAssignedEvents();
 
     /**
      * Returns the user prefs' EventTory file path.

--- a/src/main/java/seedu/eventtory/logic/Logic.java
+++ b/src/main/java/seedu/eventtory/logic/Logic.java
@@ -2,6 +2,7 @@ package seedu.eventtory.logic;
 
 import java.nio.file.Path;
 
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.eventtory.commons.core.GuiSettings;
@@ -57,6 +58,12 @@ public interface Logic {
 
     /** Returns list of associations */
     ObservableList<Association> getAssociationList();
+
+    /** Return the display index of the first vendor in the assigned list */
+    ObservableIntegerValue getAssignedVendorsDisplayStartIdx();
+
+    /** Return the display index of the first event in the assigned list */
+    ObservableIntegerValue getAssignedEventsDisplayStartIdx();
 
     /**
      * Returns the user prefs' EventTory file path.

--- a/src/main/java/seedu/eventtory/logic/LogicManager.java
+++ b/src/main/java/seedu/eventtory/logic/LogicManager.java
@@ -5,6 +5,7 @@ import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.eventtory.commons.core.GuiSettings;
@@ -101,8 +102,18 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public ObservableIntegerValue getAssignedEventsDisplayStartIdx() {
+        return model.getAssignedEventsDisplayStartIdx();
+    }
+
+    @Override
     public ObservableList<Vendor> getAssociatedVendors(Event event) {
         return model.getAssociatedVendors(event);
+    }
+
+    @Override
+    public ObservableIntegerValue getAssignedVendorsDisplayStartIdx() {
+        return model.getAssignedVendorsDisplayStartIdx();
     }
 
     @Override

--- a/src/main/java/seedu/eventtory/logic/LogicManager.java
+++ b/src/main/java/seedu/eventtory/logic/LogicManager.java
@@ -102,8 +102,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableIntegerValue getAssignedEventsDisplayStartIdx() {
-        return model.getAssignedEventsDisplayStartIdx();
+    public ObservableIntegerValue getStartingIndexOfAssignedEvents() {
+        return model.getStartingIndexOfAssignedEvents();
     }
 
     @Override
@@ -112,8 +112,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableIntegerValue getAssignedVendorsDisplayStartIdx() {
-        return model.getAssignedVendorsDisplayStartIdx();
+    public ObservableIntegerValue getStartingIndexOfAssignedVendors() {
+        return model.getStartingIndexOfAssignedVendors();
     }
 
     @Override

--- a/src/main/java/seedu/eventtory/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/AssignCommand.java
@@ -2,11 +2,10 @@ package seedu.eventtory.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
-
 import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Messages;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
+import seedu.eventtory.logic.commands.util.IndexResolverUtil;
 import seedu.eventtory.model.Model;
 import seedu.eventtory.model.event.Event;
 import seedu.eventtory.model.vendor.Vendor;
@@ -57,19 +56,8 @@ public class AssignCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        List<Vendor> vendorList = model.getFilteredVendorList();
-        List<Event> eventList = model.getFilteredEventList();
-
-        if (vendorIndex.getZeroBased() >= vendorList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
-        }
-
-        if (eventIndex.getZeroBased() >= eventList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
-        }
-
-        Vendor vendor = vendorList.get(vendorIndex.getZeroBased());
-        Event event = eventList.get(eventIndex.getZeroBased());
+        Event event = IndexResolverUtil.resolveEvent(model, eventIndex);
+        Vendor vendor = IndexResolverUtil.resolveVendor(model, vendorIndex);
 
         if (model.isVendorAssignedToEvent(vendor, event)) {
             throw new CommandException(Messages.MESSAGE_VENDOR_ALREADY_ASSIGNED);
@@ -83,4 +71,3 @@ public class AssignCommand extends Command {
                         eventIndex.getOneBased()));
     }
 }
-

--- a/src/main/java/seedu/eventtory/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/DeleteEventCommand.java
@@ -3,11 +3,10 @@ package seedu.eventtory.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.eventtory.logic.parser.CliSyntax.PREFIX_EVENT;
 
-import java.util.List;
-
 import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Messages;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
+import seedu.eventtory.logic.commands.util.IndexResolverUtil;
 import seedu.eventtory.model.Model;
 import seedu.eventtory.model.commons.exceptions.AssociationDeleteException;
 import seedu.eventtory.model.event.Event;
@@ -42,13 +41,7 @@ public class DeleteEventCommand extends DeleteCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        List<Event> lastShownList = model.getFilteredEventList();
-
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
-        }
-
-        Event eventToDelete = lastShownList.get(targetIndex.getZeroBased());
+        Event eventToDelete = IndexResolverUtil.resolveEvent(model, targetIndex);
 
         try {
             model.deleteEvent(eventToDelete);

--- a/src/main/java/seedu/eventtory/logic/commands/DeleteVendorCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/DeleteVendorCommand.java
@@ -3,11 +3,10 @@ package seedu.eventtory.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.eventtory.logic.parser.CliSyntax.PREFIX_VENDOR;
 
-import java.util.List;
-
 import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Messages;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
+import seedu.eventtory.logic.commands.util.IndexResolverUtil;
 import seedu.eventtory.model.Model;
 import seedu.eventtory.model.commons.exceptions.AssociationDeleteException;
 import seedu.eventtory.model.vendor.Vendor;
@@ -42,13 +41,7 @@ public class DeleteVendorCommand extends DeleteCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        List<Vendor> lastShownList = model.getFilteredVendorList();
-
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
-        }
-
-        Vendor vendorToDelete = lastShownList.get(targetIndex.getZeroBased());
+        Vendor vendorToDelete = IndexResolverUtil.resolveVendor(model, targetIndex);
 
         try {
             model.deleteVendor(vendorToDelete);

--- a/src/main/java/seedu/eventtory/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/EditEventCommand.java
@@ -8,7 +8,6 @@ import static seedu.eventtory.model.Model.PREDICATE_SHOW_ALL_EVENTS;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -18,6 +17,7 @@ import seedu.eventtory.commons.util.CollectionUtil;
 import seedu.eventtory.commons.util.ToStringBuilder;
 import seedu.eventtory.logic.Messages;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
+import seedu.eventtory.logic.commands.util.IndexResolverUtil;
 import seedu.eventtory.model.Model;
 import seedu.eventtory.model.commons.name.Name;
 import seedu.eventtory.model.commons.tag.Tag;
@@ -56,13 +56,8 @@ public class EditEventCommand extends EditCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Event> lastShownList = model.getFilteredEventList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
-        }
-
-        Event eventToEdit = lastShownList.get(index.getZeroBased());
+        Event eventToEdit = IndexResolverUtil.resolveEvent(model, index);
         Event editedEvent = createEditedEvent(eventToEdit, editEventDescriptor);
 
         if (!eventToEdit.isSameEvent(editedEvent) && model.hasEvent(editedEvent)) {

--- a/src/main/java/seedu/eventtory/logic/commands/EditVendorCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/EditVendorCommand.java
@@ -10,7 +10,6 @@ import static seedu.eventtory.model.Model.PREDICATE_SHOW_ALL_VENDORS;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -20,6 +19,7 @@ import seedu.eventtory.commons.util.CollectionUtil;
 import seedu.eventtory.commons.util.ToStringBuilder;
 import seedu.eventtory.logic.Messages;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
+import seedu.eventtory.logic.commands.util.IndexResolverUtil;
 import seedu.eventtory.model.Model;
 import seedu.eventtory.model.commons.name.Name;
 import seedu.eventtory.model.commons.tag.Tag;
@@ -62,13 +62,8 @@ public class EditVendorCommand extends EditCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Vendor> lastShownList = model.getFilteredVendorList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
-        }
-
-        Vendor vendorToEdit = lastShownList.get(index.getZeroBased());
+        Vendor vendorToEdit = IndexResolverUtil.resolveVendor(model, index);
         Vendor editedVendor = createEditedVendor(vendorToEdit, editVendorDescriptor);
 
         if (!vendorToEdit.isSameVendor(editedVendor) && model.hasVendor(editedVendor)) {

--- a/src/main/java/seedu/eventtory/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/UnassignCommand.java
@@ -2,11 +2,10 @@ package seedu.eventtory.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
-
 import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Messages;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
+import seedu.eventtory.logic.commands.util.IndexResolverUtil;
 import seedu.eventtory.model.Model;
 import seedu.eventtory.model.event.Event;
 import seedu.eventtory.model.vendor.Vendor;
@@ -58,19 +57,8 @@ public class UnassignCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        List<Vendor> vendorList = model.getFilteredVendorList();
-        List<Event> eventList = model.getFilteredEventList();
-
-        if (vendorIndex.getZeroBased() >= vendorList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
-        }
-
-        if (eventIndex.getZeroBased() >= eventList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
-        }
-
-        Vendor vendor = vendorList.get(vendorIndex.getZeroBased());
-        Event event = eventList.get(eventIndex.getZeroBased());
+        Vendor vendor = IndexResolverUtil.resolveVendor(model, vendorIndex);
+        Event event = IndexResolverUtil.resolveEvent(model, eventIndex);
 
         if (!model.isVendorAssignedToEvent(vendor, event)) {
             throw new CommandException(Messages.MESSAGE_VENDOR_NOT_ASSIGNED_TO_EVENT);

--- a/src/main/java/seedu/eventtory/logic/commands/ViewEventCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/ViewEventCommand.java
@@ -3,11 +3,10 @@ package seedu.eventtory.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.eventtory.logic.parser.CliSyntax.PREFIX_EVENT;
 
-import java.util.List;
-
 import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Messages;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
+import seedu.eventtory.logic.commands.util.IndexResolverUtil;
 import seedu.eventtory.model.Model;
 import seedu.eventtory.model.event.Event;
 import seedu.eventtory.ui.UiState;
@@ -31,13 +30,8 @@ public class ViewEventCommand extends ViewCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Event> lastShownList = model.getFilteredEventList();
+        Event eventToView = IndexResolverUtil.resolveEvent(model, targetIndex);
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
-        }
-
-        Event eventToView = lastShownList.get(targetIndex.getZeroBased());
         model.viewEvent(eventToView);
         model.setUiState(UiState.EVENT_DETAILS);
 

--- a/src/main/java/seedu/eventtory/logic/commands/ViewVendorCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/ViewVendorCommand.java
@@ -3,11 +3,10 @@ package seedu.eventtory.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.eventtory.logic.parser.CliSyntax.PREFIX_VENDOR;
 
-import java.util.List;
-
 import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Messages;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
+import seedu.eventtory.logic.commands.util.IndexResolverUtil;
 import seedu.eventtory.model.Model;
 import seedu.eventtory.model.vendor.Vendor;
 import seedu.eventtory.ui.UiState;
@@ -31,13 +30,8 @@ public class ViewVendorCommand extends ViewCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Vendor> lastShownList = model.getFilteredVendorList();
+        Vendor vendorToView = IndexResolverUtil.resolveVendor(model, targetIndex);
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
-        }
-
-        Vendor vendorToView = lastShownList.get(targetIndex.getZeroBased());
         model.viewVendor(vendorToView);
         model.setUiState(UiState.VENDOR_DETAILS);
 

--- a/src/main/java/seedu/eventtory/logic/commands/util/IndexResolverUtil.java
+++ b/src/main/java/seedu/eventtory/logic/commands/util/IndexResolverUtil.java
@@ -33,8 +33,11 @@ public class IndexResolverUtil {
 
             List<Vendor> associatedVendorList = model.getAssociatedVendors(viewedEvent);
 
-            return getFromTwoLists(index, mainVendorList, associatedVendorList,
-                Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
+            try {
+                return getFromTwoLists(index, mainVendorList, associatedVendorList);
+            } catch (IndexOutOfBoundsException e) {
+                throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
+            }
         } else if (index < mainVendorList.size()) {
             return mainVendorList.get(index);
         } else {
@@ -60,8 +63,11 @@ public class IndexResolverUtil {
 
             List<Event> associatedEventList = model.getAssociatedEvents(viewedVendor);
 
-            return getFromTwoLists(index, mainEventList, associatedEventList,
-                Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+            try {
+                return getFromTwoLists(index, mainEventList, associatedEventList);
+            } catch (IndexOutOfBoundsException e) {
+                throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+            }
         } else if (index < mainEventList.size()) {
             return mainEventList.get(index);
         } else {
@@ -73,8 +79,7 @@ public class IndexResolverUtil {
      * Retrieve an item from two lists, where the second list is accessed if the index overflows from the first list.
      * Index are assumed to be zero-based and non-negative.
      */
-    private static <T> T getFromTwoLists(int index, List<T> list1, List<T> list2,
-        String errorMessage) throws CommandException {
+    private static <T> T getFromTwoLists(int index, List<T> list1, List<T> list2) throws IndexOutOfBoundsException {
         assert index >= 0 : "Index should be non-negative";
 
         if (index < list1.size()) {
@@ -85,7 +90,7 @@ public class IndexResolverUtil {
             if (overflowIndex < list2.size()) {
                 return list2.get(overflowIndex);
             } else {
-                throw new CommandException(errorMessage);
+                throw new IndexOutOfBoundsException();
             }
         }
     }

--- a/src/main/java/seedu/eventtory/logic/commands/util/IndexResolverUtil.java
+++ b/src/main/java/seedu/eventtory/logic/commands/util/IndexResolverUtil.java
@@ -1,0 +1,90 @@
+package seedu.eventtory.logic.commands.util;
+
+import java.util.List;
+
+import seedu.eventtory.commons.core.index.Index;
+import seedu.eventtory.logic.Messages;
+import seedu.eventtory.logic.commands.exceptions.CommandException;
+import seedu.eventtory.model.Model;
+import seedu.eventtory.model.event.Event;
+import seedu.eventtory.model.vendor.Vendor;
+import seedu.eventtory.ui.UiState;
+
+/**
+ * Utility class to resolve indexes to their respective objects based on the current state of the UI.
+ */
+public class IndexResolverUtil {
+
+    /**
+     * Resolves the index to a vendor object.
+     * @param model the current model
+     * @param vendorIndex the index of the vendor (one-based)
+     * @return the vendor object
+     * @throws CommandException if the index is invalid
+     */
+    public static Vendor resolveVendor(Model model, Index vendorIndex) throws CommandException {
+        List<Vendor> mainVendorList = model.getFilteredVendorList();
+
+        int index = vendorIndex.getZeroBased();
+
+        if (model.getUiState().get() == UiState.EVENT_DETAILS) {
+            Event viewedEvent = model.getViewedEvent().getValue();
+            assert viewedEvent != null : "Event should not be null";
+
+            List<Vendor> associatedVendorList = model.getAssociatedVendors(viewedEvent);
+
+            return getFromTwoLists(index, mainVendorList, associatedVendorList,
+                Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
+        } else if (index >= 0 && index < mainVendorList.size()) {
+            return mainVendorList.get(index);
+        } else {
+            throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
+        }
+    }
+
+    /**
+     * Resolves the index to an event object.
+     * @param model the current model
+     * @param eventIndex the index of the event (one-based)
+     * @return the event object
+     * @throws CommandException if the index is invalid
+     */
+    public static Event resolveEvent(Model model, Index eventIndex) throws CommandException {
+        List<Event> mainEventList = model.getFilteredEventList();
+
+        int index = eventIndex.getZeroBased();
+
+        if (model.getUiState().get() == UiState.VENDOR_DETAILS) {
+            Vendor viewedVendor = model.getViewedVendor().getValue();
+            assert viewedVendor != null : "Vendor should not be null";
+
+            List<Event> associatedEventList = model.getAssociatedEvents(viewedVendor);
+
+            return getFromTwoLists(index, mainEventList, associatedEventList,
+                Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+        } else if (index >= 0 && index < mainEventList.size()) {
+            return mainEventList.get(index);
+        } else {
+            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+        }
+    }
+
+    /**
+     * Retrieve an item from two lists, where the second list is accessed if the index overflows from the first list.
+     */
+    private static <T> T getFromTwoLists(int index, List<T> list1, List<T> list2,
+        String errorMessage) throws CommandException {
+
+        if (index < list1.size()) {
+            return list1.get(index);
+        } else {
+            int overflowIndex = index - list1.size();
+
+            if (overflowIndex < list2.size()) {
+                return list2.get(overflowIndex);
+            } else {
+                throw new CommandException(errorMessage);
+            }
+        }
+    }
+}

--- a/src/main/java/seedu/eventtory/logic/commands/util/IndexResolverUtil.java
+++ b/src/main/java/seedu/eventtory/logic/commands/util/IndexResolverUtil.java
@@ -35,7 +35,7 @@ public class IndexResolverUtil {
 
             return getFromTwoLists(index, mainVendorList, associatedVendorList,
                 Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
-        } else if (index >= 0 && index < mainVendorList.size()) {
+        } else if (index < mainVendorList.size()) {
             return mainVendorList.get(index);
         } else {
             throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
@@ -62,7 +62,7 @@ public class IndexResolverUtil {
 
             return getFromTwoLists(index, mainEventList, associatedEventList,
                 Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
-        } else if (index >= 0 && index < mainEventList.size()) {
+        } else if (index < mainEventList.size()) {
             return mainEventList.get(index);
         } else {
             throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);

--- a/src/main/java/seedu/eventtory/logic/commands/util/IndexResolverUtil.java
+++ b/src/main/java/seedu/eventtory/logic/commands/util/IndexResolverUtil.java
@@ -71,9 +71,11 @@ public class IndexResolverUtil {
 
     /**
      * Retrieve an item from two lists, where the second list is accessed if the index overflows from the first list.
+     * Index are assumed to be zero-based and non-negative.
      */
     private static <T> T getFromTwoLists(int index, List<T> list1, List<T> list2,
         String errorMessage) throws CommandException {
+        assert index >= 0 : "Index should be non-negative";
 
         if (index < list1.size()) {
             return list1.get(index);

--- a/src/main/java/seedu/eventtory/model/Model.java
+++ b/src/main/java/seedu/eventtory/model/Model.java
@@ -3,6 +3,7 @@ package seedu.eventtory.model;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.eventtory.commons.core.GuiSettings;
@@ -91,6 +92,11 @@ public interface Model {
     void updateFilteredVendorList(Predicate<Vendor> predicate);
 
     /**
+     * Returns observable one-based display start index of the assigned vendor list.
+     */
+    ObservableIntegerValue getAssignedVendorsDisplayStartIdx();
+
+    /**
      * Returns true if the given {@code vendor} is already assigned to the given {@code event}. {@code vendor} and
      * {@code event} must exist in EventTory.
      */
@@ -160,6 +166,11 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredEventList(Predicate<Event> predicate);
+
+    /**
+     * Returns observable one-based display start index of the assigned event list.
+     */
+    ObservableIntegerValue getAssignedEventsDisplayStartIdx();
 
     /**
      * Returns the current selected event.

--- a/src/main/java/seedu/eventtory/model/Model.java
+++ b/src/main/java/seedu/eventtory/model/Model.java
@@ -94,7 +94,7 @@ public interface Model {
     /**
      * Returns observable one-based display start index of the assigned vendor list.
      */
-    ObservableIntegerValue getAssignedVendorsDisplayStartIdx();
+    ObservableIntegerValue getStartingIndexOfAssignedVendors();
 
     /**
      * Returns true if the given {@code vendor} is already assigned to the given {@code event}. {@code vendor} and
@@ -170,7 +170,7 @@ public interface Model {
     /**
      * Returns observable one-based display start index of the assigned event list.
      */
-    ObservableIntegerValue getAssignedEventsDisplayStartIdx();
+    ObservableIntegerValue getStartingIndexOfAssignedEvents();
 
     /**
      * Returns the current selected event.

--- a/src/main/java/seedu/eventtory/model/ModelManager.java
+++ b/src/main/java/seedu/eventtory/model/ModelManager.java
@@ -7,8 +7,10 @@ import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
+import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -33,6 +35,8 @@ public class ModelManager implements Model {
     private final FilteredList<Event> filteredEvents;
     private final ObjectProperty<Event> selectedEvent;
     private final ObjectProperty<UiState> currentUiState;
+    private final ObservableIntegerValue assignedVendorsDisplayStartIdx;
+    private final ObservableIntegerValue assignedEventsDisplayStartIdx;
 
     /**
      * Initializes a ModelManager with the given eventTory and userPrefs.
@@ -49,6 +53,13 @@ public class ModelManager implements Model {
         selectedVendor = new SimpleObjectProperty<>(null);
         selectedEvent = new SimpleObjectProperty<>(null);
         currentUiState = new SimpleObjectProperty<>(UiState.DEFAULT);
+        // one-based index
+        assignedEventsDisplayStartIdx = Bindings.createIntegerBinding(() -> {
+            return filteredEvents.size() + 1;
+        }, filteredEvents);
+        assignedVendorsDisplayStartIdx = Bindings.createIntegerBinding(() -> {
+            return filteredVendors.size() + 1;
+        }, filteredVendors);
     }
 
     public ModelManager() {
@@ -204,6 +215,11 @@ public class ModelManager implements Model {
         filteredVendors.setPredicate(predicate);
     }
 
+    @Override
+    public ObservableIntegerValue getAssignedVendorsDisplayStartIdx() {
+        return assignedVendorsDisplayStartIdx;
+    }
+
     // =========== Filtered Event List Accessors =============================================================
 
     /**
@@ -219,6 +235,11 @@ public class ModelManager implements Model {
     public void updateFilteredEventList(Predicate<Event> predicate) {
         requireNonNull(predicate);
         filteredEvents.setPredicate(predicate);
+    }
+
+    @Override
+    public ObservableIntegerValue getAssignedEventsDisplayStartIdx() {
+        return assignedEventsDisplayStartIdx;
     }
 
     @Override

--- a/src/main/java/seedu/eventtory/model/ModelManager.java
+++ b/src/main/java/seedu/eventtory/model/ModelManager.java
@@ -35,8 +35,8 @@ public class ModelManager implements Model {
     private final FilteredList<Event> filteredEvents;
     private final ObjectProperty<Event> selectedEvent;
     private final ObjectProperty<UiState> currentUiState;
-    private final ObservableIntegerValue startingIndexOfAssignedVendors;
-    private final ObservableIntegerValue startingIndexOfAssignedEvents;
+    private final ObservableIntegerValue startIndexOfAssignedVendors;
+    private final ObservableIntegerValue startIndexOfAssignedEvents;
 
     /**
      * Initializes a ModelManager with the given eventTory and userPrefs.
@@ -54,10 +54,10 @@ public class ModelManager implements Model {
         selectedEvent = new SimpleObjectProperty<>(null);
         currentUiState = new SimpleObjectProperty<>(UiState.DEFAULT);
         // one-based index
-        startingIndexOfAssignedEvents = Bindings.createIntegerBinding(() -> {
+        startIndexOfAssignedEvents = Bindings.createIntegerBinding(() -> {
             return filteredEvents.size() + 1;
         }, filteredEvents);
-        startingIndexOfAssignedVendors = Bindings.createIntegerBinding(() -> {
+        startIndexOfAssignedVendors = Bindings.createIntegerBinding(() -> {
             return filteredVendors.size() + 1;
         }, filteredVendors);
     }
@@ -217,7 +217,7 @@ public class ModelManager implements Model {
 
     @Override
     public ObservableIntegerValue getStartingIndexOfAssignedVendors() {
-        return startingIndexOfAssignedVendors;
+        return startIndexOfAssignedVendors;
     }
 
     // =========== Filtered Event List Accessors =============================================================
@@ -239,7 +239,7 @@ public class ModelManager implements Model {
 
     @Override
     public ObservableIntegerValue getStartingIndexOfAssignedEvents() {
-        return startingIndexOfAssignedEvents;
+        return startIndexOfAssignedEvents;
     }
 
     @Override

--- a/src/main/java/seedu/eventtory/model/ModelManager.java
+++ b/src/main/java/seedu/eventtory/model/ModelManager.java
@@ -35,8 +35,8 @@ public class ModelManager implements Model {
     private final FilteredList<Event> filteredEvents;
     private final ObjectProperty<Event> selectedEvent;
     private final ObjectProperty<UiState> currentUiState;
-    private final ObservableIntegerValue assignedVendorsDisplayStartIdx;
-    private final ObservableIntegerValue assignedEventsDisplayStartIdx;
+    private final ObservableIntegerValue startingIndexOfAssignedVendors;
+    private final ObservableIntegerValue startingIndexOfAssignedEvents;
 
     /**
      * Initializes a ModelManager with the given eventTory and userPrefs.
@@ -54,10 +54,10 @@ public class ModelManager implements Model {
         selectedEvent = new SimpleObjectProperty<>(null);
         currentUiState = new SimpleObjectProperty<>(UiState.DEFAULT);
         // one-based index
-        assignedEventsDisplayStartIdx = Bindings.createIntegerBinding(() -> {
+        startingIndexOfAssignedEvents = Bindings.createIntegerBinding(() -> {
             return filteredEvents.size() + 1;
         }, filteredEvents);
-        assignedVendorsDisplayStartIdx = Bindings.createIntegerBinding(() -> {
+        startingIndexOfAssignedVendors = Bindings.createIntegerBinding(() -> {
             return filteredVendors.size() + 1;
         }, filteredVendors);
     }
@@ -216,8 +216,8 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public ObservableIntegerValue getAssignedVendorsDisplayStartIdx() {
-        return assignedVendorsDisplayStartIdx;
+    public ObservableIntegerValue getStartingIndexOfAssignedVendors() {
+        return startingIndexOfAssignedVendors;
     }
 
     // =========== Filtered Event List Accessors =============================================================
@@ -238,8 +238,8 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public ObservableIntegerValue getAssignedEventsDisplayStartIdx() {
-        return assignedEventsDisplayStartIdx;
+    public ObservableIntegerValue getStartingIndexOfAssignedEvents() {
+        return startingIndexOfAssignedEvents;
     }
 
     @Override

--- a/src/main/java/seedu/eventtory/ui/EventDetailsPanel.java
+++ b/src/main/java/seedu/eventtory/ui/EventDetailsPanel.java
@@ -44,7 +44,7 @@ public class EventDetailsPanel extends UiPart<Region> {
 
     private ObservableList<Vendor> assignedVendors;
 
-    private ObservableIntegerValue displayAssignedStartIndex;
+    private ObservableIntegerValue startIndexOfAssignedVendors;
 
     /**
      * Creates a {@code VendorListPanel} with the given {@code ObservableList}.
@@ -53,7 +53,7 @@ public class EventDetailsPanel extends UiPart<Region> {
         super(FXML);
         this.logic = logic;
         assignedVendors = FXCollections.observableArrayList();
-        displayAssignedStartIndex = logic.getAssignedVendorsDisplayStartIdx();
+        startIndexOfAssignedVendors = logic.getStartingIndexOfAssignedVendors();
 
         ObservableObjectValue<Event> observableEvent = logic.getViewedEvent();
         setEvent(observableEvent.get());
@@ -71,12 +71,12 @@ public class EventDetailsPanel extends UiPart<Region> {
             updateAssignedVendors();
         });
 
-        displayAssignedStartIndex.addListener((observable, oldValue, newValue) -> {
+        startIndexOfAssignedVendors.addListener((observable, oldValue, newValue) -> {
             updateAssignedVendors();
         });
 
         VendorListPanel vendorListPanel = new VendorListPanel(
-            assignedVendors, "Assigned Vendors", displayAssignedStartIndex);
+            assignedVendors, "Assigned Vendors", startIndexOfAssignedVendors);
         detailsChildrenPlaceholder.getChildren().add(vendorListPanel.getRoot());
     }
 

--- a/src/main/java/seedu/eventtory/ui/EventDetailsPanel.java
+++ b/src/main/java/seedu/eventtory/ui/EventDetailsPanel.java
@@ -3,6 +3,7 @@ package seedu.eventtory.ui;
 import java.util.Comparator;
 import java.util.logging.Logger;
 
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
@@ -43,6 +44,8 @@ public class EventDetailsPanel extends UiPart<Region> {
 
     private ObservableList<Vendor> assignedVendors;
 
+    private ObservableIntegerValue displayAssignedStartIndex;
+
     /**
      * Creates a {@code VendorListPanel} with the given {@code ObservableList}.
      */
@@ -50,6 +53,7 @@ public class EventDetailsPanel extends UiPart<Region> {
         super(FXML);
         this.logic = logic;
         assignedVendors = FXCollections.observableArrayList();
+        displayAssignedStartIndex = logic.getAssignedVendorsDisplayStartIdx();
 
         ObservableObjectValue<Event> observableEvent = logic.getViewedEvent();
         setEvent(observableEvent.get());
@@ -67,7 +71,12 @@ public class EventDetailsPanel extends UiPart<Region> {
             updateAssignedVendors();
         });
 
-        VendorListPanel vendorListPanel = new VendorListPanel(assignedVendors, "Assigned Vendors");
+        displayAssignedStartIndex.addListener((observable, oldValue, newValue) -> {
+            updateAssignedVendors();
+        });
+
+        VendorListPanel vendorListPanel = new VendorListPanel(
+            assignedVendors, "Assigned Vendors", displayAssignedStartIndex);
         detailsChildrenPlaceholder.getChildren().add(vendorListPanel.getRoot());
     }
 

--- a/src/main/java/seedu/eventtory/ui/EventListPanel.java
+++ b/src/main/java/seedu/eventtory/ui/EventListPanel.java
@@ -2,6 +2,8 @@ package seedu.eventtory.ui;
 
 import java.util.logging.Logger;
 
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -26,11 +28,19 @@ public class EventListPanel extends UiPart<Region> {
     /**
      * Creates a {@code EventListPanel} with the given {@code ObservableList}.
      */
-    public EventListPanel(ObservableList<Event> eventList, String headerText) {
+    public EventListPanel(ObservableList<Event> eventList, String headerText,
+        ObservableIntegerValue displayIndexOffset) {
         super(FXML);
         eventListView.setItems(eventList);
-        eventListView.setCellFactory(listView -> new EventListViewCell());
+        eventListView.setCellFactory(listView -> new EventListViewCell(displayIndexOffset));
         header.setText(headerText);
+    }
+
+    /**
+     * Alternate constructor for {@code EventListPanel} with a default index offset of 1.
+     */
+    public EventListPanel(ObservableList<Event> eventList, String headerText) {
+        this(eventList, headerText, new SimpleIntegerProperty(1));
     }
 
     /**
@@ -44,6 +54,13 @@ public class EventListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Event} using a {@code EventCard}.
      */
     class EventListViewCell extends ListCell<Event> {
+        private final ObservableIntegerValue displayIndexOffset;
+
+        public EventListViewCell(ObservableIntegerValue displayIndexOffset) {
+            super();
+            this.displayIndexOffset = displayIndexOffset;
+        }
+
         @Override
         protected void updateItem(Event event, boolean empty) {
             super.updateItem(event, empty);
@@ -52,7 +69,7 @@ public class EventListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new EventCard(event, getIndex() + 1).getRoot());
+                setGraphic(new EventCard(event, getIndex() + displayIndexOffset.get()).getRoot());
             }
         }
     }

--- a/src/main/java/seedu/eventtory/ui/EventListPanel.java
+++ b/src/main/java/seedu/eventtory/ui/EventListPanel.java
@@ -29,10 +29,10 @@ public class EventListPanel extends UiPart<Region> {
      * Creates a {@code EventListPanel} with the given {@code ObservableList}.
      */
     public EventListPanel(ObservableList<Event> eventList, String headerText,
-        ObservableIntegerValue displayIndexOffset) {
+        ObservableIntegerValue indexOffset) {
         super(FXML);
         eventListView.setItems(eventList);
-        eventListView.setCellFactory(listView -> new EventListViewCell(displayIndexOffset));
+        eventListView.setCellFactory(listView -> new EventListViewCell(indexOffset));
         header.setText(headerText);
     }
 
@@ -54,11 +54,11 @@ public class EventListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Event} using a {@code EventCard}.
      */
     class EventListViewCell extends ListCell<Event> {
-        private final ObservableIntegerValue displayIndexOffset;
+        private final ObservableIntegerValue indexOffset;
 
-        public EventListViewCell(ObservableIntegerValue displayIndexOffset) {
+        public EventListViewCell(ObservableIntegerValue indexOffset) {
             super();
-            this.displayIndexOffset = displayIndexOffset;
+            this.indexOffset = indexOffset;
         }
 
         @Override
@@ -69,7 +69,7 @@ public class EventListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new EventCard(event, getIndex() + displayIndexOffset.get()).getRoot());
+                setGraphic(new EventCard(event, getIndex() + indexOffset.get()).getRoot());
             }
         }
     }

--- a/src/main/java/seedu/eventtory/ui/VendorDetailsPanel.java
+++ b/src/main/java/seedu/eventtory/ui/VendorDetailsPanel.java
@@ -47,7 +47,7 @@ public class VendorDetailsPanel extends UiPart<Region> {
 
     private ObservableList<Event> assignedEvents;
 
-    private ObservableIntegerValue displayAssignedStartIndex;
+    private ObservableIntegerValue startIndexOfAssignedEvents;
 
     /**
      * Creates a {@code VendorDetailsPanel} with the given {@code ObservableObjectValue<Vendor>} and {@code Logic}.
@@ -56,7 +56,7 @@ public class VendorDetailsPanel extends UiPart<Region> {
         super(FXML);
         this.logic = logic;
         assignedEvents = FXCollections.observableArrayList();
-        displayAssignedStartIndex = logic.getAssignedEventsDisplayStartIdx();
+        startIndexOfAssignedEvents = logic.getStartingIndexOfAssignedEvents();
 
         ObservableObjectValue<Vendor> observableVendor = logic.getViewedVendor();
         setVendor(observableVendor.get());
@@ -74,12 +74,12 @@ public class VendorDetailsPanel extends UiPart<Region> {
             updateAssignedEvents();
         });
 
-        displayAssignedStartIndex.addListener((observable, oldValue, newValue) -> {
+        startIndexOfAssignedEvents.addListener((observable, oldValue, newValue) -> {
             updateAssignedEvents();
         });
 
         EventListPanel eventListPanel = new EventListPanel(assignedEvents, "Assigned Events",
-            displayAssignedStartIndex);
+            startIndexOfAssignedEvents);
         detailsChildrenPlaceholder.getChildren().add(eventListPanel.getRoot());
     }
 

--- a/src/main/java/seedu/eventtory/ui/VendorDetailsPanel.java
+++ b/src/main/java/seedu/eventtory/ui/VendorDetailsPanel.java
@@ -3,6 +3,7 @@ package seedu.eventtory.ui;
 import java.util.Comparator;
 import java.util.logging.Logger;
 
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
@@ -46,6 +47,8 @@ public class VendorDetailsPanel extends UiPart<Region> {
 
     private ObservableList<Event> assignedEvents;
 
+    private ObservableIntegerValue displayAssignedStartIndex;
+
     /**
      * Creates a {@code VendorDetailsPanel} with the given {@code ObservableObjectValue<Vendor>} and {@code Logic}.
      */
@@ -53,6 +56,7 @@ public class VendorDetailsPanel extends UiPart<Region> {
         super(FXML);
         this.logic = logic;
         assignedEvents = FXCollections.observableArrayList();
+        displayAssignedStartIndex = logic.getAssignedEventsDisplayStartIdx();
 
         ObservableObjectValue<Vendor> observableVendor = logic.getViewedVendor();
         setVendor(observableVendor.get());
@@ -70,7 +74,12 @@ public class VendorDetailsPanel extends UiPart<Region> {
             updateAssignedEvents();
         });
 
-        EventListPanel eventListPanel = new EventListPanel(assignedEvents, "Assigned Events");
+        displayAssignedStartIndex.addListener((observable, oldValue, newValue) -> {
+            updateAssignedEvents();
+        });
+
+        EventListPanel eventListPanel = new EventListPanel(assignedEvents, "Assigned Events",
+            displayAssignedStartIndex);
         detailsChildrenPlaceholder.getChildren().add(eventListPanel.getRoot());
     }
 

--- a/src/main/java/seedu/eventtory/ui/VendorListPanel.java
+++ b/src/main/java/seedu/eventtory/ui/VendorListPanel.java
@@ -2,6 +2,8 @@ package seedu.eventtory.ui;
 
 import java.util.logging.Logger;
 
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -26,11 +28,19 @@ public class VendorListPanel extends UiPart<Region> {
     /**
      * Creates a {@code VendorListPanel} with the given {@code ObservableList}.
      */
-    public VendorListPanel(ObservableList<Vendor> vendorList, String headerText) {
+    public VendorListPanel(ObservableList<Vendor> vendorList, String headerText,
+        ObservableIntegerValue displayIndexOffset) {
         super(FXML);
         vendorListView.setItems(vendorList);
-        vendorListView.setCellFactory(listView -> new VendorListViewCell());
+        vendorListView.setCellFactory(listView -> new VendorListViewCell(displayIndexOffset));
         header.setText(headerText);
+    }
+
+    /**
+     * Alternate constructor for {@code VendorListPanel} with a default index offset of 1.
+     */
+    public VendorListPanel(ObservableList<Vendor> vendorList, String headerText) {
+        this(vendorList, headerText, new SimpleIntegerProperty(1));
     }
 
     /**
@@ -44,6 +54,13 @@ public class VendorListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Vendor} using a {@code VendorCard}.
      */
     class VendorListViewCell extends ListCell<Vendor> {
+        private final ObservableIntegerValue displayIndexOffset;
+
+        public VendorListViewCell(ObservableIntegerValue displayIndexOffset) {
+            super();
+            this.displayIndexOffset = displayIndexOffset;
+        }
+
         @Override
         protected void updateItem(Vendor vendor, boolean empty) {
             super.updateItem(vendor, empty);
@@ -52,7 +69,7 @@ public class VendorListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new VendorCard(vendor, getIndex() + 1).getRoot());
+                setGraphic(new VendorCard(vendor, getIndex() + displayIndexOffset.get()).getRoot());
             }
         }
     }

--- a/src/main/java/seedu/eventtory/ui/VendorListPanel.java
+++ b/src/main/java/seedu/eventtory/ui/VendorListPanel.java
@@ -29,10 +29,10 @@ public class VendorListPanel extends UiPart<Region> {
      * Creates a {@code VendorListPanel} with the given {@code ObservableList}.
      */
     public VendorListPanel(ObservableList<Vendor> vendorList, String headerText,
-        ObservableIntegerValue displayIndexOffset) {
+        ObservableIntegerValue indexOffset) {
         super(FXML);
         vendorListView.setItems(vendorList);
-        vendorListView.setCellFactory(listView -> new VendorListViewCell(displayIndexOffset));
+        vendorListView.setCellFactory(listView -> new VendorListViewCell(indexOffset));
         header.setText(headerText);
     }
 
@@ -54,11 +54,11 @@ public class VendorListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Vendor} using a {@code VendorCard}.
      */
     class VendorListViewCell extends ListCell<Vendor> {
-        private final ObservableIntegerValue displayIndexOffset;
+        private final ObservableIntegerValue indexOffset;
 
-        public VendorListViewCell(ObservableIntegerValue displayIndexOffset) {
+        public VendorListViewCell(ObservableIntegerValue indexOffset) {
             super();
-            this.displayIndexOffset = displayIndexOffset;
+            this.indexOffset = indexOffset;
         }
 
         @Override
@@ -69,7 +69,7 @@ public class VendorListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new VendorCard(vendor, getIndex() + displayIndexOffset.get()).getRoot());
+                setGraphic(new VendorCard(vendor, getIndex() + indexOffset.get()).getRoot());
             }
         }
     }

--- a/src/test/java/seedu/eventtory/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/eventtory/logic/LogicManagerTest.java
@@ -247,10 +247,10 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void getAssignedEventsDisplayStartIdx_setNewIndex_updateSuccessful() {
+    public void getStartingIndexOfAssignedEvents_setNewIndex_updateSuccessful() {
         ObjectProperty<Integer> observedState = new SimpleObjectProperty<>();
-        int initialIndex = logic.getAssignedEventsDisplayStartIdx().get();
-        logic.getAssignedEventsDisplayStartIdx().addListener((observable, oldValue, newValue) -> {
+        int initialIndex = logic.getStartingIndexOfAssignedEvents().get();
+        logic.getStartingIndexOfAssignedEvents().addListener((observable, oldValue, newValue) -> {
             observedState.set(newValue.intValue());
         });
 
@@ -260,10 +260,10 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void getAssignedVendorsDisplayStartIdx_setNewIndex_updateSuccessful() {
+    public void getStartingIndexOfAssignedVendors_setNewIndex_updateSuccessful() {
         ObjectProperty<Integer> observedState = new SimpleObjectProperty<>();
-        int initialIndex = logic.getAssignedVendorsDisplayStartIdx().get();
-        logic.getAssignedVendorsDisplayStartIdx().addListener((observable, oldValue, newValue) -> {
+        int initialIndex = logic.getStartingIndexOfAssignedVendors().get();
+        logic.getStartingIndexOfAssignedVendors().addListener((observable, oldValue, newValue) -> {
             observedState.set(newValue.intValue());
         });
 

--- a/src/test/java/seedu/eventtory/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/eventtory/logic/LogicManagerTest.java
@@ -246,6 +246,32 @@ public class LogicManagerTest {
         assertEquals(observedState.get(), expectedAssociation);
     }
 
+    @Test
+    public void getAssignedEventsDisplayStartIdx_setNewIndex_updateSuccessful() {
+        ObjectProperty<Integer> observedState = new SimpleObjectProperty<>();
+        int initialIndex = logic.getAssignedEventsDisplayStartIdx().get();
+        logic.getAssignedEventsDisplayStartIdx().addListener((observable, oldValue, newValue) -> {
+            observedState.set(newValue.intValue());
+        });
+
+        model.addEvent(TypicalEvents.HOON);
+
+        assertEquals(initialIndex + 1, observedState.get());
+    }
+
+    @Test
+    public void getAssignedVendorsDisplayStartIdx_setNewIndex_updateSuccessful() {
+        ObjectProperty<Integer> observedState = new SimpleObjectProperty<>();
+        int initialIndex = logic.getAssignedVendorsDisplayStartIdx().get();
+        logic.getAssignedVendorsDisplayStartIdx().addListener((observable, oldValue, newValue) -> {
+            observedState.set(newValue.intValue());
+        });
+
+        model.addVendor(TypicalVendors.AMY);
+
+        assertEquals(initialIndex + 1, observedState.get());
+    }
+
     /**
      * Executes the command and confirms that - no exceptions are thrown <br>
      * - the feedback message is equal to {@code expectedMessage} <br>

--- a/src/test/java/seedu/eventtory/logic/commands/AssignCommandTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/AssignCommandTest.java
@@ -85,6 +85,9 @@ class AssignCommandTest {
         // Same object -> returns true
         assertTrue(assignCommand.equals(assignCommand));
 
+        // different types -> returns false
+        assertFalse(assignCommand.equals(1));
+
         // Same values -> returns true
         assertTrue(assignCommand.equals(new AssignCommand(Index.fromOneBased(1), Index.fromOneBased(1))));
 

--- a/src/test/java/seedu/eventtory/logic/commands/CreateEventCommandTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/CreateEventCommandTest.java
@@ -17,8 +17,8 @@ import seedu.eventtory.model.EventTory;
 import seedu.eventtory.model.ReadOnlyEventTory;
 import seedu.eventtory.model.event.Event;
 import seedu.eventtory.testutil.EventBuilder;
-import seedu.eventtory.testutil.TypicalEvents;
 import seedu.eventtory.testutil.ModelStub;
+import seedu.eventtory.testutil.TypicalEvents;
 
 public class CreateEventCommandTest {
     @Test

--- a/src/test/java/seedu/eventtory/logic/commands/CreateEventCommandTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/CreateEventCommandTest.java
@@ -13,6 +13,7 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.eventtory.commons.core.GuiSettings;
@@ -248,6 +249,16 @@ public class CreateEventCommandTest {
 
         @Override
         public ObservableList<Association> getAssociationList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableIntegerValue getAssignedVendorsDisplayStartIdx() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableIntegerValue getAssignedEventsDisplayStartIdx() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/eventtory/logic/commands/CreateEventCommandTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/CreateEventCommandTest.java
@@ -6,29 +6,19 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.eventtory.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.beans.value.ObservableIntegerValue;
-import javafx.beans.value.ObservableObjectValue;
-import javafx.collections.ObservableList;
-import seedu.eventtory.commons.core.GuiSettings;
 import seedu.eventtory.logic.Messages;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
 import seedu.eventtory.model.EventTory;
-import seedu.eventtory.model.Model;
 import seedu.eventtory.model.ReadOnlyEventTory;
-import seedu.eventtory.model.ReadOnlyUserPrefs;
-import seedu.eventtory.model.association.Association;
 import seedu.eventtory.model.event.Event;
-import seedu.eventtory.model.vendor.Vendor;
 import seedu.eventtory.testutil.EventBuilder;
 import seedu.eventtory.testutil.TypicalEvents;
-import seedu.eventtory.ui.UiState;
+import seedu.eventtory.testutil.ModelStub;
 
 public class CreateEventCommandTest {
     @Test
@@ -53,7 +43,7 @@ public class CreateEventCommandTest {
     public void execute_duplicateVendor_throwsCommandException() {
         Event validEvent = new EventBuilder().build();
         CreateEventCommand createEventCommand = new CreateEventCommand(validEvent);
-        CreateEventCommandTest.ModelStub modelStub = new CreateEventCommandTest.ModelStubWithEvent(validEvent);
+        ModelStub modelStub = new CreateEventCommandTest.ModelStubWithEvent(validEvent);
 
         assertThrows(CommandException.class, CreateEventCommand.MESSAGE_DUPLICATE_EVENT, ()
             -> createEventCommand.execute(modelStub));
@@ -89,184 +79,9 @@ public class CreateEventCommandTest {
     }
 
     /**
-     * A default model stub that has all the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getEventToryFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setEventToryFilePath(Path eventToryFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addVendor(Vendor vendor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setEventTory(ReadOnlyEventTory newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyEventTory getEventTory() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasVendor(Vendor vendor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteVendor(Vendor target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setVendor(Vendor target, Vendor editedVendor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasEvent(Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addEvent(Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setEvent(Event target, Event editedEvent) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteEvent(Event target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Vendor> getFilteredVendorList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredVendorList(Predicate<Vendor> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Event> getFilteredEventList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredEventList(Predicate<Event> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean isVendorAssignedToEvent(Vendor vendor, Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void assignVendorToEvent(Vendor vendor, Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void unassignVendorFromEvent(Vendor vendor, Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Vendor> getAssociatedVendors(Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Event> getAssociatedEvents(Vendor vendor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setUiState(UiState uiState) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableObjectValue<UiState> getUiState() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void viewEvent(Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableObjectValue<Event> getViewedEvent() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void viewVendor(Vendor vendor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableObjectValue<Vendor> getViewedVendor() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Association> getAssociationList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableIntegerValue getAssignedVendorsDisplayStartIdx() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableIntegerValue getAssignedEventsDisplayStartIdx() {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
-    /**
      * A Model stub that contains a single event.
      */
-    private class ModelStubWithEvent extends CreateEventCommandTest.ModelStub {
+    private class ModelStubWithEvent extends ModelStub {
         private final Event event;
 
         ModelStubWithEvent(Event event) {
@@ -284,7 +99,7 @@ public class CreateEventCommandTest {
     /**
      * A Model stub that always accepts the event being added.
      */
-    private class ModelStubAcceptingEventAdded extends CreateEventCommandTest.ModelStub {
+    private class ModelStubAcceptingEventAdded extends ModelStub {
         final ArrayList<Event> eventsAdded = new ArrayList<>();
 
         @Override

--- a/src/test/java/seedu/eventtory/logic/commands/CreateVendorCommandTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/CreateVendorCommandTest.java
@@ -7,28 +7,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.eventtory.testutil.Assert.assertThrows;
 import static seedu.eventtory.testutil.TypicalVendors.ALICE;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.beans.value.ObservableIntegerValue;
-import javafx.beans.value.ObservableObjectValue;
-import javafx.collections.ObservableList;
-import seedu.eventtory.commons.core.GuiSettings;
 import seedu.eventtory.logic.Messages;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
 import seedu.eventtory.model.EventTory;
-import seedu.eventtory.model.Model;
 import seedu.eventtory.model.ReadOnlyEventTory;
-import seedu.eventtory.model.ReadOnlyUserPrefs;
-import seedu.eventtory.model.association.Association;
-import seedu.eventtory.model.event.Event;
 import seedu.eventtory.model.vendor.Vendor;
+import seedu.eventtory.testutil.ModelStub;
 import seedu.eventtory.testutil.VendorBuilder;
-import seedu.eventtory.ui.UiState;
 
 public class CreateVendorCommandTest {
 
@@ -88,181 +78,6 @@ public class CreateVendorCommandTest {
         CreateVendorCommand addCommand = new CreateVendorCommand(ALICE);
         String expected = CreateVendorCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
         assertEquals(expected, addCommand.toString());
-    }
-
-    /**
-     * A default model stub that has all the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getEventToryFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setEventToryFilePath(Path eventToryFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addVendor(Vendor vendor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setEventTory(ReadOnlyEventTory newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyEventTory getEventTory() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasVendor(Vendor vendor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteVendor(Vendor target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setVendor(Vendor target, Vendor editedVendor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasEvent(Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addEvent(Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteEvent(Event target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setEvent(Event target, Event editedEvent) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Vendor> getFilteredVendorList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredVendorList(Predicate<Vendor> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Event> getFilteredEventList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableObjectValue<Vendor> getViewedVendor() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void viewVendor(Vendor vendor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredEventList(Predicate<Event> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean isVendorAssignedToEvent(Vendor vendor, Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void assignVendorToEvent(Vendor vendor, Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void unassignVendorFromEvent(Vendor vendor, Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Vendor> getAssociatedVendors(Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Event> getAssociatedEvents(Vendor vendor) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableObjectValue<Event> getViewedEvent() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void viewEvent(Event event) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableObjectValue<UiState> getUiState() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setUiState(UiState uiState) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Association> getAssociationList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableIntegerValue getAssignedVendorsDisplayStartIdx() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableIntegerValue getAssignedEventsDisplayStartIdx() {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 
     /**

--- a/src/test/java/seedu/eventtory/logic/commands/CreateVendorCommandTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/CreateVendorCommandTest.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.eventtory.commons.core.GuiSettings;
@@ -250,6 +251,16 @@ public class CreateVendorCommandTest {
 
         @Override
         public ObservableList<Association> getAssociationList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableIntegerValue getAssignedVendorsDisplayStartIdx() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableIntegerValue getAssignedEventsDisplayStartIdx() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/eventtory/logic/commands/EditEventCommandTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/EditEventCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.eventtory.logic.commands.CommandTestUtil.DESC_BIRTHDAY;
 import static seedu.eventtory.logic.commands.CommandTestUtil.DESC_WEDDING;
 import static seedu.eventtory.logic.commands.CommandTestUtil.VALID_NAME_BIRTHDAY;
+import static seedu.eventtory.logic.commands.CommandTestUtil.VALID_TAG_CHARITY;
 import static seedu.eventtory.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.eventtory.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.eventtory.logic.commands.CommandTestUtil.showEventAtIndex;
@@ -167,8 +168,14 @@ public class EditEventCommandTest {
         // different index -> returns false
         assertFalse(standardCommand.equals(new EditEventCommand(INDEX_SECOND_EVENT, DESC_WEDDING)));
 
-        // different descriptor -> returns false
+        // different date descriptor -> returns false
         assertFalse(standardCommand.equals(new EditEventCommand(INDEX_FIRST_EVENT, DESC_BIRTHDAY)));
+
+        // different tags descriptor -> returns false
+        EditEventDescriptor differentTag = new EditEventDescriptorBuilder(DESC_WEDDING)
+                .withTags(VALID_TAG_CHARITY)
+                .build();
+        assertFalse(standardCommand.equals(new EditEventCommand(INDEX_FIRST_EVENT, differentTag)));
     }
 
     @Test

--- a/src/test/java/seedu/eventtory/logic/commands/util/IndexResolverUtilTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/util/IndexResolverUtilTest.java
@@ -1,0 +1,127 @@
+package seedu.eventtory.logic.commands.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.eventtory.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+import static seedu.eventtory.testutil.TypicalIndexes.INDEX_FIRST_VENDOR;
+import static seedu.eventtory.testutil.TypicalIndexes.INDEX_LAST_EVENT;
+import static seedu.eventtory.testutil.TypicalIndexes.INDEX_LAST_VENDOR;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.eventtory.commons.core.index.Index;
+import seedu.eventtory.logic.Messages;
+import seedu.eventtory.logic.commands.exceptions.CommandException;
+import seedu.eventtory.model.Model;
+import seedu.eventtory.model.ModelManager;
+import seedu.eventtory.model.UserPrefs;
+import seedu.eventtory.model.event.Event;
+import seedu.eventtory.model.vendor.Vendor;
+import seedu.eventtory.testutil.TypicalEvents;
+import seedu.eventtory.testutil.TypicalVendors;
+import seedu.eventtory.testutil.TypicalVendorsEventsCombined;
+import seedu.eventtory.ui.UiState;
+
+// TODO: Might have to update index after the association filter is merged #116
+public class IndexResolverUtilTest {
+    private static final Index INDEX_OVERFLOW_VENDOR = Index.fromOneBased(
+        INDEX_LAST_VENDOR.getOneBased() + 1);
+    private static final Index INDEX_OVERFLOW_EVENT = Index.fromOneBased(
+        INDEX_LAST_VENDOR.getOneBased() + 1);
+    private static final Index INDEX_OVERFLOW_VENDOR_ASSOCIATED = Index.fromOneBased(
+        INDEX_LAST_EVENT.getOneBased() + 2);
+    private static final Index INDEX_OVERFLOW_EVENT_ASSOCIATED = Index.fromOneBased(
+        INDEX_LAST_EVENT.getOneBased() + 2);
+    private Model model;
+    private Vendor vendor1 = TypicalVendors.ALICE;
+    private Vendor vendor2 = TypicalVendors.BENSON;
+    private Event event1 = TypicalEvents.ALICE;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(TypicalVendorsEventsCombined.getTypicalEventTory(), new UserPrefs());
+        model.assignVendorToEvent(vendor2, event1);
+    }
+
+    @Test
+    public void testResolveVendor_mainListIndex_valid() throws CommandException {
+        model.setUiState(UiState.DEFAULT);
+
+        assertEquals(vendor1, IndexResolverUtil.resolveVendor(model, INDEX_FIRST_VENDOR));
+    }
+
+    @Test
+    public void testResolveVendor_eventDetailsIndexOverflowToAssociatedList_valid() throws CommandException {
+
+        // Set UiState to EVENT_DETAILS with associated vendors
+        model.viewEvent(event1);
+        model.setUiState(UiState.EVENT_DETAILS);
+
+        // Overflow to associated list
+        assertEquals(vendor2, IndexResolverUtil.resolveVendor(model, Index.fromOneBased(8)));
+    }
+
+    @Test
+    public void testResolveVendor_mainListIndex_invalid() {
+        model.setUiState(UiState.DEFAULT);
+
+        CommandException exception = assertThrows(CommandException.class, () -> {
+            IndexResolverUtil.resolveVendor(model, INDEX_OVERFLOW_VENDOR);
+        });
+        assertEquals(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX, exception.getMessage());
+    }
+
+    @Test
+    public void testResolveVendor_eventDetailsIndex_invalidOverflow() {
+        // Set UiState to EVENT_DETAILS with one associated vendor
+        model.setUiState(UiState.EVENT_DETAILS);
+        model.viewEvent(event1);
+
+        // Expect CommandException for index exceeding both lists
+        CommandException exception = assertThrows(CommandException.class, () -> {
+            IndexResolverUtil.resolveVendor(model, INDEX_OVERFLOW_VENDOR_ASSOCIATED);
+        });
+        assertEquals(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX, exception.getMessage());
+    }
+
+    @Test
+    public void testResolveEvent_mainListIndex_valid() throws CommandException {
+        model.setUiState(UiState.DEFAULT);
+
+        assertEquals(event1, IndexResolverUtil.resolveEvent(model, INDEX_FIRST_EVENT));
+    }
+
+    @Test
+    public void testResolveEvent_vendorDetailsIndexOverflowToAssociatedList_valid() throws CommandException {
+        // Set UiState to VENDOR_DETAILS with associated events
+        model.setUiState(UiState.VENDOR_DETAILS);
+        model.viewVendor(vendor2);
+
+        // Overflow to associated list
+        assertEquals(event1, IndexResolverUtil.resolveEvent(model, INDEX_OVERFLOW_EVENT));
+    }
+
+    @Test
+    public void testResolveEvent_mainListIndex_invalid() {
+        model.setUiState(UiState.DEFAULT);
+
+        CommandException exception = assertThrows(CommandException.class, () -> {
+            IndexResolverUtil.resolveEvent(model, INDEX_OVERFLOW_EVENT);
+        });
+        assertEquals(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX, exception.getMessage());
+    }
+
+    @Test
+    public void testResolveEvent_vendorDetailsIndex_invalidOverflow() {
+        // Set UiState to VENDOR_DETAILS with one associated event
+        model.setUiState(UiState.VENDOR_DETAILS);
+        model.viewVendor(vendor1);
+
+        // Expect CommandException for index exceeding both lists
+        CommandException exception = assertThrows(CommandException.class, () -> {
+            IndexResolverUtil.resolveEvent(model, INDEX_OVERFLOW_EVENT_ASSOCIATED);
+        });
+        assertEquals(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX, exception.getMessage());
+    }
+}

--- a/src/test/java/seedu/eventtory/logic/commands/util/IndexResolverUtilTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/util/IndexResolverUtilTest.java
@@ -9,6 +9,7 @@ import static seedu.eventtory.testutil.TypicalIndexes.INDEX_LAST_VENDOR;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import java.util.List;
 
 import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Messages;
@@ -36,7 +37,9 @@ public class IndexResolverUtilTest {
     private Model model;
     private Vendor vendor1 = TypicalVendors.ALICE;
     private Vendor vendor2 = TypicalVendors.BENSON;
+    private Vendor vendor7 = TypicalVendors.GEORGE;
     private Event event1 = TypicalEvents.ALICE;
+    private Event event7 = TypicalEvents.GEORGE;
 
     @BeforeEach
     public void setUp() {
@@ -45,10 +48,17 @@ public class IndexResolverUtilTest {
     }
 
     @Test
-    public void testResolveVendor_mainListIndex_valid() throws CommandException {
+    public void testResolveVendor_mainListIndexFirst_valid() throws CommandException {
         model.setUiState(UiState.DEFAULT);
 
         assertEquals(vendor1, IndexResolverUtil.resolveVendor(model, INDEX_FIRST_VENDOR));
+    }
+
+    @Test
+    public void testResolveVendor_mainListIndexLast_valid() throws CommandException {
+        model.setUiState(UiState.DEFAULT);
+
+        assertEquals(vendor7, IndexResolverUtil.resolveVendor(model, INDEX_LAST_VENDOR));
     }
 
     @Test
@@ -59,7 +69,7 @@ public class IndexResolverUtilTest {
         model.setUiState(UiState.EVENT_DETAILS);
 
         // Overflow to associated list
-        assertEquals(vendor2, IndexResolverUtil.resolveVendor(model, Index.fromOneBased(8)));
+        assertEquals(vendor2, IndexResolverUtil.resolveVendor(model, INDEX_OVERFLOW_VENDOR));
     }
 
     @Test
@@ -86,10 +96,17 @@ public class IndexResolverUtilTest {
     }
 
     @Test
-    public void testResolveEvent_mainListIndex_valid() throws CommandException {
+    public void testResolveEvent_mainListIndexFirst_valid() throws CommandException {
         model.setUiState(UiState.DEFAULT);
 
         assertEquals(event1, IndexResolverUtil.resolveEvent(model, INDEX_FIRST_EVENT));
+    }
+
+    @Test
+    public void testResolveEvent_mainListIndexLast_valid() throws CommandException {
+        model.setUiState(UiState.DEFAULT);
+
+        assertEquals(event7, IndexResolverUtil.resolveEvent(model, INDEX_LAST_EVENT));
     }
 
     @Test

--- a/src/test/java/seedu/eventtory/logic/commands/util/IndexResolverUtilTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/util/IndexResolverUtilTest.java
@@ -61,6 +61,15 @@ public class IndexResolverUtilTest {
     }
 
     @Test
+    public void testResolveVendor_eventDetailsMainListIndex_valid() throws CommandException {
+        // Set UiState to EVENT_DETAILS with no associated vendors
+        model.viewEvent(event7);
+        model.setUiState(UiState.EVENT_DETAILS);
+
+        assertEquals(vendor1, IndexResolverUtil.resolveVendor(model, INDEX_FIRST_VENDOR));
+    }
+
+    @Test
     public void testResolveVendor_eventDetailsIndexOverflowToAssociatedList_valid() throws CommandException {
 
         // Set UiState to EVENT_DETAILS with associated vendors
@@ -106,6 +115,15 @@ public class IndexResolverUtilTest {
         model.setUiState(UiState.DEFAULT);
 
         assertEquals(event7, IndexResolverUtil.resolveEvent(model, INDEX_LAST_EVENT));
+    }
+
+    @Test
+    public void testResolveEvent_vendorDetailsMainListIndex_valid() throws CommandException {
+        // Set UiState to VENDOR_DETAILS with no associated events
+        model.setUiState(UiState.VENDOR_DETAILS);
+        model.viewVendor(vendor7);
+
+        assertEquals(event1, IndexResolverUtil.resolveEvent(model, INDEX_FIRST_EVENT));
     }
 
     @Test

--- a/src/test/java/seedu/eventtory/logic/commands/util/IndexResolverUtilTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/util/IndexResolverUtilTest.java
@@ -9,7 +9,6 @@ import static seedu.eventtory.testutil.TypicalIndexes.INDEX_LAST_VENDOR;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import java.util.List;
 
 import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Messages;

--- a/src/test/java/seedu/eventtory/model/ModelManagerTest.java
+++ b/src/test/java/seedu/eventtory/model/ModelManagerTest.java
@@ -268,20 +268,20 @@ public class ModelManagerTest {
 
     @Test
     public void testAssignedEventsDisplayStartIdx_updatesWithEventListSize() {
-        assertEquals(1, modelManager.getAssignedEventsDisplayStartIdx().get());
+        assertEquals(1, modelManager.getStartingIndexOfAssignedEvents().get());
 
         modelManager.addEvent(TypicalEvents.HOON);
 
-        assertEquals(2, modelManager.getAssignedEventsDisplayStartIdx().get());
+        assertEquals(2, modelManager.getStartingIndexOfAssignedEvents().get());
     }
 
     @Test
     public void testAssignedVendorsDisplayStartIdx_updatesWithVendorListSize() {
-        assertEquals(1, modelManager.getAssignedVendorsDisplayStartIdx().get());
+        assertEquals(1, modelManager.getStartingIndexOfAssignedVendors().get());
 
         modelManager.addVendor(TypicalVendors.HOON);
 
-        assertEquals(2, modelManager.getAssignedVendorsDisplayStartIdx().get());
+        assertEquals(2, modelManager.getStartingIndexOfAssignedVendors().get());
     }
 
     @Test

--- a/src/test/java/seedu/eventtory/model/ModelManagerTest.java
+++ b/src/test/java/seedu/eventtory/model/ModelManagerTest.java
@@ -267,6 +267,24 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void testAssignedEventsDisplayStartIdx_updatesWithEventListSize() {
+        assertEquals(1, modelManager.getAssignedEventsDisplayStartIdx().get());
+
+        modelManager.addEvent(TypicalEvents.HOON);
+
+        assertEquals(2, modelManager.getAssignedEventsDisplayStartIdx().get());
+    }
+
+    @Test
+    public void testAssignedVendorsDisplayStartIdx_updatesWithVendorListSize() {
+        assertEquals(1, modelManager.getAssignedVendorsDisplayStartIdx().get());
+
+        modelManager.addVendor(TypicalVendors.HOON);
+
+        assertEquals(2, modelManager.getAssignedVendorsDisplayStartIdx().get());
+    }
+
+    @Test
     public void equals() {
         EventTory eventTory = new EventToryBuilder().withVendor(ALICE).withVendor(BENSON).build();
         EventTory differentEventTory = new EventTory();
@@ -303,4 +321,3 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(eventTory, differentUserPrefs)));
     }
 }
-

--- a/src/test/java/seedu/eventtory/model/commons/tag/TagTest.java
+++ b/src/test/java/seedu/eventtory/model/commons/tag/TagTest.java
@@ -1,5 +1,8 @@
 package seedu.eventtory.model.commons.tag;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import static seedu.eventtory.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -21,6 +24,25 @@ public class TagTest {
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+    }
+
+    @Test
+    public void equals() {
+        Tag tag = new Tag("tag");
+        // same values -> returns true
+        assertTrue(tag.equals(new Tag("tag")));
+
+        // same object -> returns true
+        assertTrue(tag.equals(tag));
+
+        // null -> returns false
+        assertFalse(tag.equals(null));
+
+        // different type -> returns false
+        assertFalse(tag.equals(5));
+
+        // different tag -> returns false
+        assertFalse(tag.equals(new Tag("different")));
     }
 
 }

--- a/src/test/java/seedu/eventtory/model/commons/tag/TagTest.java
+++ b/src/test/java/seedu/eventtory/model/commons/tag/TagTest.java
@@ -2,7 +2,6 @@ package seedu.eventtory.model.commons.tag;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import static seedu.eventtory.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/eventtory/testutil/EditEventDescriptorBuilder.java
+++ b/src/test/java/seedu/eventtory/testutil/EditEventDescriptorBuilder.java
@@ -1,7 +1,12 @@
 package seedu.eventtory.testutil;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import seedu.eventtory.logic.commands.EditEventCommand.EditEventDescriptor;
 import seedu.eventtory.model.commons.name.Name;
+import seedu.eventtory.model.commons.tag.Tag;
 import seedu.eventtory.model.event.Date;
 import seedu.eventtory.model.event.Event;
 
@@ -28,6 +33,7 @@ public class EditEventDescriptorBuilder {
         descriptor = new EditEventDescriptor();
         descriptor.setName(event.getName());
         descriptor.setDate(event.getDate());
+        descriptor.setTags(event.getTags());
     }
 
     /**
@@ -45,6 +51,16 @@ public class EditEventDescriptorBuilder {
      */
     public EditEventDescriptorBuilder withDate(String date) {
         descriptor.setDate(new Date(date));
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the
+     * {@code EditEventDescriptor} that we are building.
+     */
+    public EditEventDescriptorBuilder withTags(String... tags) {
+        Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
+        descriptor.setTags(tagSet);
         return this;
     }
 

--- a/src/test/java/seedu/eventtory/testutil/EventBuilder.java
+++ b/src/test/java/seedu/eventtory/testutil/EventBuilder.java
@@ -36,7 +36,7 @@ public class EventBuilder {
     public EventBuilder(Event eventToCopy) {
         name = eventToCopy.getName();
         date = eventToCopy.getDate();
-        tags = new HashSet<>(eventToCopy.getTags());
+        tags = eventToCopy.getTags();
     }
 
     /**

--- a/src/test/java/seedu/eventtory/testutil/EventBuilder.java
+++ b/src/test/java/seedu/eventtory/testutil/EventBuilder.java
@@ -36,7 +36,7 @@ public class EventBuilder {
     public EventBuilder(Event eventToCopy) {
         name = eventToCopy.getName();
         date = eventToCopy.getDate();
-        tags = eventToCopy.getTags();
+        tags = new HashSet<>(eventToCopy.getTags());
     }
 
     /**

--- a/src/test/java/seedu/eventtory/testutil/EventUtil.java
+++ b/src/test/java/seedu/eventtory/testutil/EventUtil.java
@@ -5,8 +5,11 @@ import static seedu.eventtory.logic.parser.CliSyntax.PREFIX_EVENT;
 import static seedu.eventtory.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.eventtory.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.Set;
+
 import seedu.eventtory.logic.commands.CreateEventCommand;
 import seedu.eventtory.logic.commands.EditEventCommand.EditEventDescriptor;
+import seedu.eventtory.model.commons.tag.Tag;
 import seedu.eventtory.model.event.Event;
 
 /**
@@ -40,6 +43,14 @@ public class EventUtil {
         StringBuilder sb = new StringBuilder();
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getDate().ifPresent(date -> sb.append(PREFIX_DATE).append(date.toString()).append(" "));
+        if (descriptor.getTags().isPresent()) {
+            Set<Tag> tags = descriptor.getTags().get();
+            if (tags.isEmpty()) {
+                sb.append(PREFIX_TAG);
+            } else {
+                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
+            }
+        }
         return sb.toString();
     }
 }

--- a/src/test/java/seedu/eventtory/testutil/ModelStub.java
+++ b/src/test/java/seedu/eventtory/testutil/ModelStub.java
@@ -180,12 +180,12 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public ObservableIntegerValue getAssignedVendorsDisplayStartIdx() {
+    public ObservableIntegerValue getStartingIndexOfAssignedVendors() {
         throw new AssertionError("This method should not be called.");
     }
 
     @Override
-    public ObservableIntegerValue getAssignedEventsDisplayStartIdx() {
+    public ObservableIntegerValue getStartingIndexOfAssignedEvents() {
         throw new AssertionError("This method should not be called.");
     }
 }

--- a/src/test/java/seedu/eventtory/testutil/ModelStub.java
+++ b/src/test/java/seedu/eventtory/testutil/ModelStub.java
@@ -1,0 +1,191 @@
+package seedu.eventtory.testutil;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import javafx.beans.value.ObservableIntegerValue;
+import javafx.beans.value.ObservableObjectValue;
+import javafx.collections.ObservableList;
+import seedu.eventtory.commons.core.GuiSettings;
+import seedu.eventtory.model.Model;
+import seedu.eventtory.model.ReadOnlyEventTory;
+import seedu.eventtory.model.ReadOnlyUserPrefs;
+import seedu.eventtory.model.association.Association;
+import seedu.eventtory.model.event.Event;
+import seedu.eventtory.model.vendor.Vendor;
+import seedu.eventtory.ui.UiState;
+
+/**
+ * A default model stub that has all the methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getEventToryFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setEventToryFilePath(Path eventToryFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addVendor(Vendor vendor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setEventTory(ReadOnlyEventTory newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyEventTory getEventTory() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasVendor(Vendor vendor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteVendor(Vendor target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setVendor(Vendor target, Vendor editedVendor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasEvent(Event event) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addEvent(Event event) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setEvent(Event target, Event editedEvent) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteEvent(Event target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Vendor> getFilteredVendorList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredVendorList(Predicate<Vendor> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Event> getFilteredEventList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredEventList(Predicate<Event> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean isVendorAssignedToEvent(Vendor vendor, Event event) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void assignVendorToEvent(Vendor vendor, Event event) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void unassignVendorFromEvent(Vendor vendor, Event event) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Vendor> getAssociatedVendors(Event event) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Event> getAssociatedEvents(Vendor vendor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setUiState(UiState uiState) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableObjectValue<UiState> getUiState() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void viewEvent(Event event) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableObjectValue<Event> getViewedEvent() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void viewVendor(Vendor vendor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableObjectValue<Vendor> getViewedVendor() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Association> getAssociationList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableIntegerValue getAssignedVendorsDisplayStartIdx() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableIntegerValue getAssignedEventsDisplayStartIdx() {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/seedu/eventtory/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/eventtory/testutil/TypicalIndexes.java
@@ -13,4 +13,6 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_EVENT = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_EVENT = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_EVENT = Index.fromOneBased(3);
+    public static final Index INDEX_LAST_VENDOR = Index.fromOneBased(7);
+    public static final Index INDEX_LAST_EVENT = Index.fromOneBased(7);
 }

--- a/src/test/java/seedu/eventtory/testutil/VendorBuilder.java
+++ b/src/test/java/seedu/eventtory/testutil/VendorBuilder.java
@@ -46,7 +46,7 @@ public class VendorBuilder {
         name = vendorToCopy.getName();
         phone = vendorToCopy.getPhone();
         description = vendorToCopy.getDescription();
-        tags = new HashSet<>(vendorToCopy.getTags());
+        tags = vendorToCopy.getTags();
     }
 
     /**


### PR DESCRIPTION
Assigned events/vendors now have their index starting +1 from the last number in assignable.
As such there should be no more ambiguity which index is being referred to in the user's input command.

Added a `IndexResolverUtil` that takes in vendor, event index and return a vendor, model based on the current UI display state (changes the trailing to a proper idx pointing to assigned). 
The util class also does checks and throw exception if index is out of bounds

Resolves: #149 