### PR TITLE
Tags are Case Sensitive

### DIFF
--- a/src/main/java/seedu/eventtory/model/commons/tag/Tag.java
+++ b/src/main/java/seedu/eventtory/model/commons/tag/Tag.java
@@ -4,8 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.eventtory.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Tag in EventTory.
- * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
+ * Represents a Tag in EventTory. Tags will always be lowercase.
+ * Guarantees: immutable; tag is valid as declared in {@link #isValidTagName(String)}
  */
 public class Tag {
 
@@ -22,7 +22,7 @@ public class Tag {
     public Tag(String tagName) {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+        this.tagName = tagName.toLowerCase();
     }
 
     /**

--- a/src/main/java/seedu/eventtory/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/eventtory/storage/JsonAdaptedTag.java
@@ -18,7 +18,7 @@ class JsonAdaptedTag {
      */
     @JsonCreator
     public JsonAdaptedTag(String tagName) {
-        this.tagName = tagName;
+        this.tagName = tagName.toLowerCase();
     }
 
     /**

--- a/src/test/java/seedu/eventtory/model/commons/tag/TagTest.java
+++ b/src/test/java/seedu/eventtory/model/commons/tag/TagTest.java
@@ -23,6 +23,14 @@ public class TagTest {
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+
+        // with special characters
+        assertFalse(() -> Tag.isValidTagName("tag_name"));
+
+        // valid tags
+        assertTrue(() -> Tag.isValidTagName("tagname"));
+        assertTrue(() -> Tag.isValidTagName("TAGNAME"));
+        assertTrue(() -> Tag.isValidTagName("tagname"));
     }
 
     @Test
@@ -42,6 +50,9 @@ public class TagTest {
 
         // different tag -> returns false
         assertFalse(tag.equals(new Tag("different")));
+
+        // same tags but difference case -> returns true
+        assertTrue(tag.equals(new Tag("TAG")));
     }
 
 }


### PR DESCRIPTION
Resolves #164 

Tags are now stored in lowercase. 
- Tags such as "Name", "NAME" and "name" will all be treated to be "name".
- This might be bad for tags that use captialisation to differentiate between acronyms and other words. E.g. "CAT" (Caterpillar Inc.) and "cat" (the animal), but this can be addressed in #167 by allowed non-alphanumeric characters