### PR TITLE
Make inputs more forgiving

### DIFF
--- a/src/main/java/seedu/eventtory/model/commons/name/Name.java
+++ b/src/main/java/seedu/eventtory/model/commons/name/Name.java
@@ -9,14 +9,13 @@ import static seedu.eventtory.commons.util.AppUtil.checkArgument;
  */
 public class Name {
     public static final String MESSAGE_CONSTRAINTS =
-            "Names cannot contain '/' and should not be blank";
+            "Names must start with an alphanumeric character and must not contain '/'.";
 
     /*
      * The first character of a name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
-     * Forward slashes are also not allowed as they conflict with command syntax.
      */
-    public static final String VALIDATION_REGEX = "^[^\\s/][^/]*$";
+    public static final String VALIDATION_REGEX = "^\\p{Alnum}[^/]*$";
 
     public final String fullName;
 

--- a/src/main/java/seedu/eventtory/model/commons/name/Name.java
+++ b/src/main/java/seedu/eventtory/model/commons/name/Name.java
@@ -9,7 +9,7 @@ import static seedu.eventtory.commons.util.AppUtil.checkArgument;
  */
 public class Name {
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names cannot contain '/' and should not be blank";
 
     /*
      * The first character of a name must not be a whitespace,

--- a/src/main/java/seedu/eventtory/model/commons/name/Name.java
+++ b/src/main/java/seedu/eventtory/model/commons/name/Name.java
@@ -12,10 +12,11 @@ public class Name {
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
-     * The first character of the eventtory must not be a whitespace,
+     * The first character of a name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
+     * Forward slashes are also not allowed as they conflict with command syntax.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[^\\s/][^/]*$";
 
     public final String fullName;
 

--- a/src/main/java/seedu/eventtory/model/commons/tag/Tag.java
+++ b/src/main/java/seedu/eventtory/model/commons/tag/Tag.java
@@ -9,8 +9,10 @@ import static seedu.eventtory.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = """
+            Tags can contain alphanumeric characters, hyphens '-', and underscores '_' only.
+            Tags cannot be made up of only hyphens '-' and underscores '_'.""";
+    public static final String VALIDATION_REGEX = "^(?=.*\\p{Alnum})[\\p{Alnum}_-]+$";
 
     public final String tagName;
 

--- a/src/test/java/seedu/eventtory/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/eventtory/logic/commands/CommandTestUtil.java
@@ -50,7 +50,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
-    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
+    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "/James/"; // '/' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     // empty string not allowed for description
     public static final String INVALID_DESCRIPTION_DESC = " " + PREFIX_DESCRIPTION;

--- a/src/test/java/seedu/eventtory/logic/parser/CreateEventCommandParserTest.java
+++ b/src/test/java/seedu/eventtory/logic/parser/CreateEventCommandParserTest.java
@@ -94,7 +94,7 @@ public class CreateEventCommandParserTest {
     }
 
     @Test
-    public void parse_invalidValue_failure() {
+    public void parse() {
         // invalid name
         assertParseFailure(parser, " " + PREFIX_EVENT + INVALID_NAME_DESC + DATE_DESC_BIRTHDAY,
                 Name.MESSAGE_CONSTRAINTS);
@@ -105,8 +105,8 @@ public class CreateEventCommandParserTest {
                 Date.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, " " + PREFIX_EVENT + " " + PREFIX_NAME + "Zoo Excursion?" + " "
-                        + PREFIX_DATE + "10 October 2024",
+        assertParseFailure(parser, " " + PREFIX_EVENT + " " + PREFIX_NAME + "Zoo Excursion/" + " "
+                        + PREFIX_DATE + "32 October 2024",
                 Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble

--- a/src/test/java/seedu/eventtory/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/eventtory/logic/parser/ParserUtilTest.java
@@ -21,8 +21,8 @@ import seedu.eventtory.model.vendor.Description;
 import seedu.eventtory.model.vendor.Phone;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_EVENT_NAME = "Zoo?";
+    private static final String INVALID_NAME = "Ra/chel";
+    private static final String INVALID_EVENT_NAME = "Zoo/";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_DESCRIPTION = " ";
     private static final String INVALID_TAG = "#friend";

--- a/src/test/java/seedu/eventtory/model/commons/name/NameTest.java
+++ b/src/test/java/seedu/eventtory/model/commons/name/NameTest.java
@@ -27,15 +27,19 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
-        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("/")); // with forward slash
+        assertFalse(Name.isValidName("/testName")); // with forward slash at start
+        assertFalse(Name.isValidName("test/Name")); // with forward slash in middle
+        assertFalse(Name.isValidName("testName/")); // with forward slash at end
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
+        assertTrue(Name.isValidName("peter*")); // contains non-alphanumeric characters
         assertTrue(Name.isValidName("12345")); // numbers only
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("{:><;['.?\"}")); // special characters (Excluding '/') only
     }
 
     @Test

--- a/src/test/java/seedu/eventtory/model/commons/name/NameTest.java
+++ b/src/test/java/seedu/eventtory/model/commons/name/NameTest.java
@@ -31,6 +31,7 @@ public class NameTest {
         assertFalse(Name.isValidName("/testName")); // with forward slash at start
         assertFalse(Name.isValidName("test/Name")); // with forward slash in middle
         assertFalse(Name.isValidName("testName/")); // with forward slash at end
+        assertFalse(Name.isValidName("{:><;['.?\"}")); // special characters only
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
@@ -39,7 +40,9 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
-        assertTrue(Name.isValidName("{:><;['.?\"}")); // special characters (Excluding '/') only
+
+        // special characters (Excluding '/') with leading alphanumeric character
+        assertTrue(Name.isValidName("a{:><;['.?\"}"));
     }
 
     @Test

--- a/src/test/java/seedu/eventtory/storage/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/eventtory/storage/JsonAdaptedEventTest.java
@@ -19,7 +19,7 @@ import seedu.eventtory.model.event.Date;
 import seedu.eventtory.model.id.UniqueId;
 
 public class JsonAdaptedEventTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "Ra/chel";
     private static final String INVALID_DATE = "10 Octo 2024";
     private static final String INVALID_TAG = "#hiking";
 

--- a/src/test/java/seedu/eventtory/storage/JsonAdaptedVendorTest.java
+++ b/src/test/java/seedu/eventtory/storage/JsonAdaptedVendorTest.java
@@ -18,7 +18,7 @@ import seedu.eventtory.model.vendor.Description;
 import seedu.eventtory.model.vendor.Phone;
 
 public class JsonAdaptedVendorTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "Ra/chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_DESCRIPTION = " ";
     private static final String INVALID_TAG = "#friend";


### PR DESCRIPTION
Resolves #167

Changed input fields to accept more input strings.

### Name
1. Must start with an alphanumeric character <- not sure if this is too arbitrary
2. Must NOT contain '/'

### Tag
1. Can contain only alphanumeric characters, hyphens '-', and underscores '_' (this naturally excludes the use of '/' as well)
2. Cannot be made up of only hyphens '-' and underscores '_'
3. Can start with hyphens '-' and underscores '_' (if the user chooses to do so)
4. Is more relaxed compared to `Name`

### Description
1. No change, should it be changed to disallow forward slashes '/' as well? 