### PR TITLE
Return to default view when selected object is deleted

### DIFF
--- a/src/main/java/seedu/eventtory/model/ModelManager.java
+++ b/src/main/java/seedu/eventtory/model/ModelManager.java
@@ -127,6 +127,12 @@ public class ModelManager implements Model {
     @Override
     public void deleteVendor(Vendor target) throws AssociationDeleteException {
         eventTory.removeVendor(target);
+        // Only reset view if the deleted vendor is the currently viewed vendor and
+        // deletion is successful (error not thrown)
+        if (currentUiState.get() == UiState.VENDOR_DETAILS && target.isSameId(selectedVendor.getValue())) {
+            selectedVendor.setValue(null);
+            currentUiState.setValue(UiState.DEFAULT);
+        }
     }
 
     @Override
@@ -151,6 +157,12 @@ public class ModelManager implements Model {
     @Override
     public void deleteEvent(Event target) throws AssociationDeleteException {
         eventTory.removeEvent(target);
+        // Only reset view if the deleted event is the currently viewed event and
+        // deletion is successful (error not thrown)
+        if (currentUiState.get() == UiState.EVENT_DETAILS && target.isSameId(selectedEvent.getValue())) {
+            selectedEvent.setValue(null);
+            currentUiState.setValue(UiState.DEFAULT);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/eventtory/model/ModelManager.java
+++ b/src/main/java/seedu/eventtory/model/ModelManager.java
@@ -129,7 +129,7 @@ public class ModelManager implements Model {
         eventTory.removeVendor(target);
         // Only reset view if the deleted vendor is the currently viewed vendor and
         // deletion is successful (error not thrown)
-        if (currentUiState.get() == UiState.VENDOR_DETAILS && target.isSameId(selectedVendor.getValue())) {
+        if (currentUiState.get().isVendorDetails() && target.isSameId(selectedVendor.getValue())) {
             selectedVendor.setValue(null);
             currentUiState.setValue(UiState.DEFAULT);
         }
@@ -159,7 +159,7 @@ public class ModelManager implements Model {
         eventTory.removeEvent(target);
         // Only reset view if the deleted event is the currently viewed event and
         // deletion is successful (error not thrown)
-        if (currentUiState.get() == UiState.EVENT_DETAILS && target.isSameId(selectedEvent.getValue())) {
+        if (currentUiState.get().isEventDetails() && target.isSameId(selectedEvent.getValue())) {
             selectedEvent.setValue(null);
             currentUiState.setValue(UiState.DEFAULT);
         }
@@ -290,7 +290,7 @@ public class ModelManager implements Model {
     }
 
     private Predicate<Vendor> evaluateVendorPredicate() {
-        if (currentUiState.getValue() == UiState.EVENT_DETAILS) {
+        if (currentUiState.getValue().isEventDetails()) {
             Predicate<Vendor> notAssociatedPredicate = vendor -> {
                 Event event = selectedEvent.getValue();
                 return event != null && !isVendorAssignedToEvent(vendor, event);
@@ -301,7 +301,7 @@ public class ModelManager implements Model {
     }
 
     private Predicate<Event> evaluateEventPredicate() {
-        if (currentUiState.getValue() == UiState.VENDOR_DETAILS) {
+        if (currentUiState.getValue().isVendorDetails()) {
             Predicate<Event> notAssociatedPredicate = event -> {
                 Vendor vendor = selectedVendor.getValue();
                 return vendor != null && !isVendorAssignedToEvent(vendor, event);

--- a/src/main/java/seedu/eventtory/model/event/Event.java
+++ b/src/main/java/seedu/eventtory/model/event/Event.java
@@ -92,10 +92,6 @@ public class Event {
      * @return boolean
      */
     public boolean isSameId(Event otherEvent) {
-        if (otherEvent == this) {
-            return true;
-        }
-
         return otherEvent != null
                 && otherEvent.getId().equals(getId());
     }

--- a/src/main/java/seedu/eventtory/model/event/Event.java
+++ b/src/main/java/seedu/eventtory/model/event/Event.java
@@ -86,6 +86,20 @@ public class Event {
                 && otherEvent.getName().equals(getName());
     }
 
+    /**
+     * Returns true if both events have the same Unique Id.
+     * @param otherEvent
+     * @return boolean
+     */
+    public boolean isSameId(Event otherEvent) {
+        if (otherEvent == this) {
+            return true;
+        }
+
+        return otherEvent != null
+                && otherEvent.getId().equals(getId());
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/eventtory/model/vendor/Vendor.java
+++ b/src/main/java/seedu/eventtory/model/vendor/Vendor.java
@@ -105,6 +105,20 @@ public class Vendor {
     }
 
     /**
+     * Returns true if both vendors have the same Unique Id.
+     * @param otherVendor
+     * @return boolean
+     */
+    public boolean isSameId(Vendor otherVendor) {
+        if (otherVendor == this) {
+            return true;
+        }
+
+        return otherVendor != null
+                && otherVendor.getId().equals(getId());
+    }
+
+    /**
      * Returns true if both vendors have the same identity and data fields.
      * This defines a stronger notion of equality between two vendors.
      */

--- a/src/main/java/seedu/eventtory/model/vendor/Vendor.java
+++ b/src/main/java/seedu/eventtory/model/vendor/Vendor.java
@@ -110,10 +110,6 @@ public class Vendor {
      * @return boolean
      */
     public boolean isSameId(Vendor otherVendor) {
-        if (otherVendor == this) {
-            return true;
-        }
-
         return otherVendor != null
                 && otherVendor.getId().equals(getId());
     }

--- a/src/main/java/seedu/eventtory/ui/UiState.java
+++ b/src/main/java/seedu/eventtory/ui/UiState.java
@@ -4,5 +4,29 @@ package seedu.eventtory.ui;
  * Represents the current state of the UI.
  */
 public enum UiState {
-    DEFAULT, VENDOR_LIST, VENDOR_DETAILS, EVENT_LIST, EVENT_DETAILS
+    DEFAULT, VENDOR_LIST, VENDOR_DETAILS, EVENT_LIST, EVENT_DETAILS;
+
+    public boolean isState(UiState state) {
+        return this == state;
+    }
+
+    public boolean isDefault() {
+        return isState(DEFAULT);
+    }
+
+    public boolean isVendorList() {
+        return isState(VENDOR_LIST);
+    }
+
+    public boolean isVendorDetails() {
+        return isState(VENDOR_DETAILS);
+    }
+
+    public boolean isEventList() {
+        return isState(EVENT_LIST);
+    }
+
+    public boolean isEventDetails() {
+        return isState(EVENT_DETAILS);
+    }
 }

--- a/src/test/java/seedu/eventtory/logic/commands/DeleteEventCommandTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/DeleteEventCommandTest.java
@@ -19,6 +19,7 @@ import seedu.eventtory.model.ModelManager;
 import seedu.eventtory.model.UserPrefs;
 import seedu.eventtory.model.event.Event;
 import seedu.eventtory.model.vendor.Vendor;
+import seedu.eventtory.ui.UiState;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -92,6 +93,20 @@ public class DeleteEventCommandTest {
                 Messages.format(eventToDelete));
 
         assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_viewedEvent_changeUiState() {
+        Event eventToDelete = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        model.viewEvent(eventToDelete);
+        DeleteEventCommand deleteCommand = new DeleteEventCommand(INDEX_FIRST_EVENT);
+
+        try {
+            deleteCommand.execute(model);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        assertFalse(model.getUiState().get() == UiState.EVENT_DETAILS);
     }
 
     @Test

--- a/src/test/java/seedu/eventtory/logic/commands/DeleteVendorCommandTest.java
+++ b/src/test/java/seedu/eventtory/logic/commands/DeleteVendorCommandTest.java
@@ -19,10 +19,10 @@ import seedu.eventtory.model.ModelManager;
 import seedu.eventtory.model.UserPrefs;
 import seedu.eventtory.model.event.Event;
 import seedu.eventtory.model.vendor.Vendor;
+import seedu.eventtory.ui.UiState;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for
- * {@code DeleteVendorCommand}.
+ * Contains integration tests (interaction with the Model) and unit tests for {@code DeleteVendorCommand}.
  */
 public class DeleteVendorCommandTest {
 
@@ -92,6 +92,20 @@ public class DeleteVendorCommandTest {
                 Messages.format(vendorToDelete));
 
         assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_viewedVendor_changeUiState() {
+        Vendor vendorToDelete = model.getFilteredVendorList().get(INDEX_FIRST_VENDOR.getZeroBased());
+        model.viewVendor(vendorToDelete);
+        DeleteVendorCommand deleteCommand = new DeleteVendorCommand(INDEX_FIRST_VENDOR);
+
+        try {
+            deleteCommand.execute(model);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        assertFalse(model.getUiState().get() == UiState.VENDOR_DETAILS);
     }
 
     @Test

--- a/src/test/java/seedu/eventtory/model/event/EventTest.java
+++ b/src/test/java/seedu/eventtory/model/event/EventTest.java
@@ -71,6 +71,11 @@ public class EventTest {
     }
 
     @Test
+    public void isSameEventId_nullEvent_returnsFalse() {
+        assertFalse(WEDDING.isSameId(null));
+    }
+
+    @Test
     public void isSameEvent_eventWithSameIdentity_returnsTrue() {
         Event similarWedding = new EventBuilder(WEDDING).withDate(VALID_DATE_BIRTHDAY).build();
         assertTrue(WEDDING.isSameEvent(similarWedding));

--- a/src/test/java/seedu/eventtory/model/event/EventTest.java
+++ b/src/test/java/seedu/eventtory/model/event/EventTest.java
@@ -61,6 +61,16 @@ public class EventTest {
     }
 
     @Test
+    public void isSameEventId_sameEvent_returnsTrue() {
+        assertTrue(WEDDING.isSameId(WEDDING));
+    }
+
+    @Test
+    public void isSameEventId_differentEvent_returnsFalse() {
+        assertFalse(WEDDING.isSameId(BIRTHDAY));
+    }
+
+    @Test
     public void isSameEvent_eventWithSameIdentity_returnsTrue() {
         Event similarWedding = new EventBuilder(WEDDING).withDate(VALID_DATE_BIRTHDAY).build();
         assertTrue(WEDDING.isSameEvent(similarWedding));
@@ -136,4 +146,3 @@ public class EventTest {
         assertEquals(expected, event.toString());
     }
 }
-

--- a/src/test/java/seedu/eventtory/model/vendor/VendorTest.java
+++ b/src/test/java/seedu/eventtory/model/vendor/VendorTest.java
@@ -31,6 +31,12 @@ public class VendorTest {
         // null -> returns false
         assertFalse(ALICE.isSameVendor(null));
 
+        // same id -> returns true
+        assertTrue(ALICE.isSameId(ALICE));
+
+        // different id -> returns false
+        assertFalse(ALICE.isSameId(BOB));
+
         // same name, all other attributes different -> returns true
         Vendor editedAlice = new VendorBuilder(ALICE).withPhone(VALID_PHONE_BOB)
                 .withDescription(VALID_DESCRIPTION_BOB).withTags(VALID_TAG_HUSBAND).build();

--- a/src/test/java/seedu/eventtory/model/vendor/VendorTest.java
+++ b/src/test/java/seedu/eventtory/model/vendor/VendorTest.java
@@ -37,6 +37,9 @@ public class VendorTest {
         // different id -> returns false
         assertFalse(ALICE.isSameId(BOB));
 
+        // null -> returns false
+        assertFalse(ALICE.isSameId(null));
+
         // same name, all other attributes different -> returns true
         Vendor editedAlice = new VendorBuilder(ALICE).withPhone(VALID_PHONE_BOB)
                 .withDescription(VALID_DESCRIPTION_BOB).withTags(VALID_TAG_HUSBAND).build();


### PR DESCRIPTION
Reading the PR explains the PR
Closes #165 

Additional Changes
- Method to check for `UniqueId` equality

# Note

View is only changed to default when:
- Deleted object is current selected object
- Deletion is successful (explicit by error not being thrown)
- Current view is detailed view of the deleted object