### PR TITLE
Tag cannot display long inputs

### DIFF
--- a/src/main/java/seedu/eventtory/model/commons/tag/Tag.java
+++ b/src/main/java/seedu/eventtory/model/commons/tag/Tag.java
@@ -11,8 +11,9 @@ public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = """
             Tags can contain alphanumeric characters, hyphens '-', and underscores '_' only.
-            Tags cannot be made up of only hyphens '-' and underscores '_'.""";
+            Tags cannot be made up of only hyphens '-' and underscores '_' and can only be 30 characters max""";
     public static final String VALIDATION_REGEX = "^(?=.*\\p{Alnum})[\\p{Alnum}_-]+$";
+    public static final int MAXIMUM_LENGTH = 30;
 
     public final String tagName;
 
@@ -31,6 +32,9 @@ public class Tag {
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidTagName(String test) {
+        if (test.length() > MAXIMUM_LENGTH) {
+            return false;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/test/java/seedu/eventtory/model/commons/tag/TagTest.java
+++ b/src/test/java/seedu/eventtory/model/commons/tag/TagTest.java
@@ -28,6 +28,8 @@ public class TagTest {
         assertFalse(() -> Tag.isValidTagName("-"));
         assertFalse(() -> Tag.isValidTagName("_"));
         assertFalse(() -> Tag.isValidTagName("-_"));
+        assertFalse(() -> Tag.isValidTagName("abcdefghijklmnopqrstuvwxyz12345")); // length 31, too long
+        assertFalse(() -> Tag.isValidTagName("abcdefghijklmnopqrstuvwxyz1234567890")); // length 36, too long
 
         // valid tags
         assertTrue(() -> Tag.isValidTagName("-tag"));
@@ -37,6 +39,7 @@ public class TagTest {
         assertTrue(() -> Tag.isValidTagName("tagname"));
         assertTrue(() -> Tag.isValidTagName("TAGNAME"));
         assertTrue(() -> Tag.isValidTagName("tagname"));
+        assertTrue(() -> Tag.isValidTagName("abcdefghijklmnopqrstuvwxyz1234")); // length 30, acceptable
     }
 
     @Test


### PR DESCRIPTION
Resolves #205

Tags can only be of length 30 max now. This is to prevent ugly rendering.