### PR TITLE
Fix bugs regarding viewed object index

### DIFF
--- a/src/main/java/seedu/eventtory/logic/Logic.java
+++ b/src/main/java/seedu/eventtory/logic/Logic.java
@@ -6,7 +6,6 @@ import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.eventtory.commons.core.GuiSettings;
-import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.commands.CommandResult;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
 import seedu.eventtory.logic.parser.exceptions.ParseException;
@@ -25,13 +24,12 @@ public interface Logic {
      * @param commandText The command as entered by the user.
      * @return the result of the command execution.
      * @throws CommandException If an error occurs during command execution.
-     * @throws ParseException If an error occurs during parsing.
+     * @throws ParseException   If an error occurs during parsing.
      */
     CommandResult execute(String commandText) throws CommandException, ParseException;
 
     /**
      * Returns the EventTory.
-     *
      * @see seedu.eventtory.model.Model#getEventTory()
      */
     ReadOnlyEventTory getEventTory();
@@ -67,10 +65,13 @@ public interface Logic {
     ObservableIntegerValue getStartingIndexOfAssignedEvents();
 
     /** Return the display index of the given vendor in the filtered list */
-    Index getRelativeIndexOfVendor(Vendor vendor);
+    int getRelativeIndexOfVendor(Vendor vendor);
 
     /** Return the display index of the given event in the filtered list */
-    Index getRelativeIndexOfEvent(Event event);
+    int getRelativeIndexOfEvent(Event event);
+
+    /** Return the display index of the selected object */
+    ObservableIntegerValue getIndexOfSelectedObject();
 
     /**
      * Returns the user prefs' EventTory file path.

--- a/src/main/java/seedu/eventtory/logic/Logic.java
+++ b/src/main/java/seedu/eventtory/logic/Logic.java
@@ -24,7 +24,7 @@ public interface Logic {
      * @param commandText The command as entered by the user.
      * @return the result of the command execution.
      * @throws CommandException If an error occurs during command execution.
-     * @throws ParseException   If an error occurs during parsing.
+     * @throws ParseException If an error occurs during parsing.
      */
     CommandResult execute(String commandText) throws CommandException, ParseException;
 

--- a/src/main/java/seedu/eventtory/logic/LogicManager.java
+++ b/src/main/java/seedu/eventtory/logic/LogicManager.java
@@ -10,7 +10,6 @@ import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.eventtory.commons.core.GuiSettings;
 import seedu.eventtory.commons.core.LogsCenter;
-import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.commands.Command;
 import seedu.eventtory.logic.commands.CommandResult;
 import seedu.eventtory.logic.commands.exceptions.CommandException;
@@ -123,13 +122,18 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public Index getRelativeIndexOfVendor(Vendor vendor) {
+    public int getRelativeIndexOfVendor(Vendor vendor) {
         return model.getRelativeIndexOfVendor(vendor);
     }
 
     @Override
-    public Index getRelativeIndexOfEvent(Event event) {
+    public int getRelativeIndexOfEvent(Event event) {
         return model.getRelativeIndexOfEvent(event);
+    }
+
+    @Override
+    public ObservableIntegerValue getIndexOfSelectedObject() {
+        return model.getIndexOfSelectedObject();
     }
 
     @Override

--- a/src/main/java/seedu/eventtory/logic/commands/ViewEventCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/ViewEventCommand.java
@@ -32,7 +32,6 @@ public class ViewEventCommand extends ViewCommand {
         Event eventToView = IndexResolverUtil.resolveEvent(model, targetIndex);
 
         model.viewEvent(eventToView);
-        model.updateFilteredVendorList(Model.PREDICATE_SHOW_ALL_VENDORS);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(eventToView)));
     }

--- a/src/main/java/seedu/eventtory/logic/commands/ViewVendorCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/ViewVendorCommand.java
@@ -2,7 +2,6 @@ package seedu.eventtory.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.eventtory.logic.parser.CliSyntax.PREFIX_VENDOR;
-import static seedu.eventtory.model.Model.PREDICATE_SHOW_ALL_EVENTS;
 
 import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Messages;
@@ -33,7 +32,6 @@ public class ViewVendorCommand extends ViewCommand {
         Vendor vendorToView = IndexResolverUtil.resolveVendor(model, targetIndex);
 
         model.viewVendor(vendorToView);
-        model.updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(vendorToView)));
     }

--- a/src/main/java/seedu/eventtory/model/Model.java
+++ b/src/main/java/seedu/eventtory/model/Model.java
@@ -7,7 +7,6 @@ import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.eventtory.commons.core.GuiSettings;
-import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.model.association.Association;
 import seedu.eventtory.model.commons.exceptions.AssociationDeleteException;
 import seedu.eventtory.model.event.Event;

--- a/src/main/java/seedu/eventtory/model/Model.java
+++ b/src/main/java/seedu/eventtory/model/Model.java
@@ -136,12 +136,17 @@ public interface Model {
     /**
      * Returns the relative index of the vendor in the filtered list.
      */
-    Index getRelativeIndexOfVendor(Vendor vendor);
+    int getRelativeIndexOfVendor(Vendor vendor);
 
     /**
      * Returns the relative index of the event in the filtered list.
      */
-    Index getRelativeIndexOfEvent(Event event);
+    int getRelativeIndexOfEvent(Event event);
+
+    /**
+     * Returns the relative index of the selected object in the filtered list.
+     */
+    ObservableIntegerValue getIndexOfSelectedObject();
 
     /**
      * Sets the selected vendor.

--- a/src/main/java/seedu/eventtory/ui/EventDetailsPanel.java
+++ b/src/main/java/seedu/eventtory/ui/EventDetailsPanel.java
@@ -15,7 +15,6 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import seedu.eventtory.commons.core.LogsCenter;
-import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Logic;
 import seedu.eventtory.model.association.Association;
 import seedu.eventtory.model.event.Event;
@@ -30,6 +29,8 @@ public class EventDetailsPanel extends UiPart<Region> {
     private final Logic logic;
     private final Logger logger = LogsCenter.getLogger(VendorDetailsPanel.class);
 
+    @FXML
+    private Label index;
     @FXML
     private Label name;
     @FXML
@@ -57,9 +58,14 @@ public class EventDetailsPanel extends UiPart<Region> {
         startIndexOfAssignedVendors = logic.getStartingIndexOfAssignedVendors();
 
         ObservableObjectValue<Event> observableEvent = logic.getViewedEvent();
+        ObservableIntegerValue relativeIndexOfEvent = logic.getIndexOfSelectedObject();
+
+        relativeIndexOfEvent.addListener((observable, oldValue, newValue) -> {
+            setIndex(newValue.intValue());
+        });
 
         observableEvent.addListener((observable, oldValue, newValue) -> {
-            setEvent(newValue, this.logic.getRelativeIndexOfEvent(newValue));
+            setEvent(newValue);
             showEventDetails();
             updateAssignedVendors();
         });
@@ -78,10 +84,10 @@ public class EventDetailsPanel extends UiPart<Region> {
         detailsChildrenPlaceholder.getChildren().add(vendorListPanel.getRoot());
     }
 
-    private void setEvent(Event event, Index index) {
+    private void setEvent(Event event) {
         this.event = event;
         if (event != null) {
-            String nameWithIndex = String.format("%d. %s", index.getZeroBased() + 1, event.getName().fullName);
+            String nameWithIndex = event.getName().fullName;
             name.setText(nameWithIndex);
             date.setText(event.getDate().toString());
             // Empty tags will leave behind the last set of tags,
@@ -93,6 +99,10 @@ public class EventDetailsPanel extends UiPart<Region> {
             name.setText("");
             date.setText("");
         }
+    }
+
+    private void setIndex(int index) {
+        this.index.setText(String.format("%d. ", index + 1));
     }
 
     private void showEventDetails() {

--- a/src/main/java/seedu/eventtory/ui/VendorDetailsPanel.java
+++ b/src/main/java/seedu/eventtory/ui/VendorDetailsPanel.java
@@ -16,7 +16,6 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
 import seedu.eventtory.commons.core.LogsCenter;
-import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.logic.Logic;
 import seedu.eventtory.model.association.Association;
 import seedu.eventtory.model.event.Event;
@@ -31,6 +30,8 @@ public class VendorDetailsPanel extends UiPart<Region> {
     private final Logic logic;
     private final Logger logger = LogsCenter.getLogger(VendorDetailsPanel.class);
 
+    @FXML
+    private Label index;
     @FXML
     private Label name;
     @FXML
@@ -60,9 +61,14 @@ public class VendorDetailsPanel extends UiPart<Region> {
         startIndexOfAssignedEvents = logic.getStartingIndexOfAssignedEvents();
 
         ObservableObjectValue<Vendor> observableVendor = logic.getViewedVendor();
+        ObservableIntegerValue relativeIndexOfVendor = logic.getIndexOfSelectedObject();
+
+        relativeIndexOfVendor.addListener((observable, oldValue, newValue) -> {
+            setIndex(newValue.intValue());
+        });
 
         observableVendor.addListener((observable, oldValue, newValue) -> {
-            setVendor(newValue, logic.getRelativeIndexOfVendor(newValue));
+            setVendor(newValue);
             showVendorDetails();
             updateAssignedEvents();
         });
@@ -81,10 +87,10 @@ public class VendorDetailsPanel extends UiPart<Region> {
         detailsChildrenPlaceholder.getChildren().add(eventListPanel.getRoot());
     }
 
-    private void setVendor(Vendor vendor, Index index) {
+    private void setVendor(Vendor vendor) {
         this.vendor = vendor;
         if (vendor != null) {
-            String nameWithIndex = String.format("%d. %s", index.getZeroBased() + 1, vendor.getName().fullName);
+            String nameWithIndex = vendor.getName().fullName;
             name.setText(nameWithIndex);
             phone.setText(vendor.getPhone().value);
             description.setText(vendor.getDescription().value);
@@ -98,6 +104,10 @@ public class VendorDetailsPanel extends UiPart<Region> {
             phone.setText("");
             description.setText("");
         }
+    }
+
+    private void setIndex(int index) {
+        this.index.setText(String.format("%d. ", index + 1));
     }
 
     private void showVendorDetails() {

--- a/src/main/resources/view/EventDetailsPanel.fxml
+++ b/src/main/resources/view/EventDetailsPanel.fxml
@@ -18,7 +18,12 @@
                <Insets bottom="10.0" right="15.0" top="10.0" />
             </padding>
          </Label>
-         <Label fx:id="name" styleClass="label-header" text="\$name" textFill="WHITE" />
+         <FlowPane>
+            <children>
+               <Label fx:id="index" styleClass="label-header" text="\$id" textFill="WHITE" />
+               <Label fx:id="name" styleClass="label-header" text="\$name" textFill="WHITE" />
+            </children>
+         </FlowPane>
          <FlowPane fx:id="tags">
             <padding>
                <Insets top="5.0" />

--- a/src/main/resources/view/VendorDetailsPanel.fxml
+++ b/src/main/resources/view/VendorDetailsPanel.fxml
@@ -21,11 +21,20 @@
                <Insets bottom="10.0" right="15.0" top="10.0" />
             </padding>
          </Label>
-         <Label fx:id="name" styleClass="label-header" text="\$name" textFill="WHITE">
-            <font>
-               <Font size="20.0" />
-            </font>
-         </Label>
+         <FlowPane>
+            <children>
+               <Label fx:id="index" styleClass="label-header" text="\$id" textFill="WHITE">
+                  <font>
+                     <Font size="20.0" />
+                  </font>
+               </Label>
+               <Label fx:id="name" styleClass="label-header" text="\$name" textFill="WHITE">
+                  <font>
+                     <Font size="20.0" />
+                  </font>
+               </Label>
+            </children>
+         </FlowPane>
          <FlowPane fx:id="tags">
             <padding>
                <Insets top="5.0" />

--- a/src/test/java/seedu/eventtory/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/eventtory/logic/LogicManagerTest.java
@@ -280,8 +280,8 @@ public class LogicManagerTest {
         model.addEvent(indexOneEvent);
         model.addEvent(indexTwoEvent);
 
-        assertEquals(0, this.logic.getRelativeIndexOfEvent(indexOneEvent).getZeroBased());
-        assertEquals(1, this.logic.getRelativeIndexOfEvent(indexTwoEvent).getZeroBased());
+        assertEquals(0, this.logic.getRelativeIndexOfEvent(indexOneEvent));
+        assertEquals(1, this.logic.getRelativeIndexOfEvent(indexTwoEvent));
     }
 
     @Test
@@ -291,8 +291,21 @@ public class LogicManagerTest {
         model.addVendor(indexOneVendor);
         model.addVendor(indexTwoVendor);
 
-        assertEquals(0, this.logic.getRelativeIndexOfVendor(indexOneVendor).getZeroBased());
-        assertEquals(1, this.logic.getRelativeIndexOfVendor(indexTwoVendor).getZeroBased());
+        assertEquals(0, this.logic.getRelativeIndexOfVendor(indexOneVendor));
+        assertEquals(1, this.logic.getRelativeIndexOfVendor(indexTwoVendor));
+    }
+
+    @Test
+    public void getIndexOfSelectedObject() {
+        Event indexOneEvent = new EventBuilder().withName("Event 1").build();
+        Event indexTwoEvent = new EventBuilder().withName("Event 2").build();
+        model.addEvent(indexOneEvent);
+        model.addEvent(indexTwoEvent);
+
+        model.viewEvent(indexOneEvent);
+        this.logic.getIndexOfSelectedObject().addListener((observable, oldValue, newValue) -> {
+            assertEquals(1, newValue.intValue());
+        });
     }
 
     /**

--- a/src/test/java/seedu/eventtory/testutil/ModelStub.java
+++ b/src/test/java/seedu/eventtory/testutil/ModelStub.java
@@ -7,7 +7,6 @@ import javafx.beans.value.ObservableIntegerValue;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.eventtory.commons.core.GuiSettings;
-import seedu.eventtory.commons.core.index.Index;
 import seedu.eventtory.model.Model;
 import seedu.eventtory.model.ReadOnlyEventTory;
 import seedu.eventtory.model.ReadOnlyUserPrefs;
@@ -191,12 +190,17 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public Index getRelativeIndexOfEvent(Event event) {
+    public int getRelativeIndexOfEvent(Event event) {
         throw new AssertionError("This method should not be called.");
     }
 
     @Override
-    public Index getRelativeIndexOfVendor(Vendor vendor) {
+    public int getRelativeIndexOfVendor(Vendor vendor) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableIntegerValue getIndexOfSelectedObject() {
         throw new AssertionError("This method should not be called.");
     }
 }


### PR DESCRIPTION
Index of viewed object was dependent on filteredList to be updated which depended on viewedObject to be updated first. It is possible to update indexOfViewedObject together with viewedObject without waiting for filteredList to be updated. So it is refactored out