### PR TITLE
Fix index 0 showing up after nested find and view operation

### DIFF
--- a/src/main/java/seedu/eventtory/logic/commands/ViewEventCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/ViewEventCommand.java
@@ -31,6 +31,10 @@ public class ViewEventCommand extends ViewCommand {
         requireNonNull(model);
         Event eventToView = IndexResolverUtil.resolveEvent(model, targetIndex);
 
+        // Reset filtered event list to prevent not being able to find the event after viewing
+        if (model.getUiState().getValue().isVendorDetails()) {
+            model.updateFilteredEventList(Model.PREDICATE_SHOW_ALL_EVENTS);
+        }
         model.viewEvent(eventToView);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(eventToView)));

--- a/src/main/java/seedu/eventtory/logic/commands/ViewVendorCommand.java
+++ b/src/main/java/seedu/eventtory/logic/commands/ViewVendorCommand.java
@@ -31,6 +31,10 @@ public class ViewVendorCommand extends ViewCommand {
         requireNonNull(model);
         Vendor vendorToView = IndexResolverUtil.resolveVendor(model, targetIndex);
 
+        // Reset filtered vendor list to prevent not being able to find the vendor after viewing
+        if (model.getUiState().getValue().isEventDetails()) {
+            model.updateFilteredVendorList(Model.PREDICATE_SHOW_ALL_VENDORS);
+        }
         model.viewVendor(vendorToView);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(vendorToView)));

--- a/src/main/java/seedu/eventtory/model/ModelManager.java
+++ b/src/main/java/seedu/eventtory/model/ModelManager.java
@@ -319,8 +319,6 @@ public class ModelManager implements Model {
                 return event != null && !isVendorAssignedToEvent(vendor, event);
             };
             return combinePredicates(notAssociatedPredicate, suppliedVendorFilterPredicate.getValue());
-        } else if (currentUiState.getValue().isVendorDetails()) {
-            return PREDICATE_SHOW_ALL_VENDORS;
         }
         return suppliedVendorFilterPredicate.getValue();
     }
@@ -332,8 +330,6 @@ public class ModelManager implements Model {
                 return vendor != null && !isVendorAssignedToEvent(vendor, event);
             };
             return combinePredicates(notAssociatedPredicate, suppliedEventFilterPredicate.getValue());
-        } else if (currentUiState.getValue().isEventDetails()) {
-            return PREDICATE_SHOW_ALL_EVENTS;
         }
         return suppliedEventFilterPredicate.getValue();
     }

--- a/src/main/java/seedu/eventtory/model/ModelManager.java
+++ b/src/main/java/seedu/eventtory/model/ModelManager.java
@@ -319,6 +319,8 @@ public class ModelManager implements Model {
                 return event != null && !isVendorAssignedToEvent(vendor, event);
             };
             return combinePredicates(notAssociatedPredicate, suppliedVendorFilterPredicate.getValue());
+        } else if (currentUiState.getValue().isVendorDetails()) {
+            return PREDICATE_SHOW_ALL_VENDORS;
         }
         return suppliedVendorFilterPredicate.getValue();
     }
@@ -330,6 +332,8 @@ public class ModelManager implements Model {
                 return vendor != null && !isVendorAssignedToEvent(vendor, event);
             };
             return combinePredicates(notAssociatedPredicate, suppliedEventFilterPredicate.getValue());
+        } else if (currentUiState.getValue().isEventDetails()) {
+            return PREDICATE_SHOW_ALL_EVENTS;
         }
         return suppliedEventFilterPredicate.getValue();
     }


### PR DESCRIPTION
# Summary

- Viewing an item that was filtered out will result in the relative index label to be 0 **(unexpected behaviour)**
- Reset the filtered list of the item before viewing to prevent it not being able to be found
- Reset is only done when going from one item view to another to maintain the find operation as long as possible